### PR TITLE
Fix for evaluation of distribution release and default provider.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Select NTP implementation
   set_fact:
-    ntp_implementation: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare('6.8', '<') else 'chrony' }}"
+    ntp_implementation: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version|version_compare('7', '<') else 'chrony' }}"
   when: sync_mode != 2
 
 - name: Install chrony


### PR DESCRIPTION
@mlichvar  @larskarlitski   I must admit I did not test this, but the prior logic did not seem to properly account for RHEL version >= 6.8.