### PR TITLE
Select currently active/enabled NTP provider by default (rhbz#1597692)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ clock_step_threshold: 1.0
 # Minimum number of selectable time sources required to allow synchronization
 # of the clock (default 1)
 min_time_sources: 1
+
+# Name of the package which should be installed and configured for NTP.
+# Possible values are "chrony" and "ntp". If not defined, the currently active
+# or enabled service will be configured. If no service is active or enabled, a
+# package specific to the system and its version will be selected.
+ntp_provider: chrony
 ```
 
 Example Playbook

--- a/library/timesync_provider.sh
+++ b/library/timesync_provider.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# WANT_JSON
+
+is_service_enabled() {
+	local name=$1 runlevel prev_runlevel
+
+	read -r prev_runlevel runlevel < <(runlevel)
+
+	systemctl is-enabled $name.service &> /dev/null || \
+		chkconfig --list $name 2>/dev/null | grep -q "$runlevel:on"
+}
+
+is_service_active() {
+	local name=$1
+
+	systemctl is-active $name.service &> /dev/null || \
+		service $name status &>/dev/null
+}
+
+get_current_ntp_providers() {
+	is_service_active chronyd || is_service_enabled chronyd && echo chrony
+	is_service_active ntpd || is_service_enabled ntpd && echo ntp
+}
+
+get_default_ntp_provider() {
+	[ -e /etc/os-release ] && . /etc/os-release &> /dev/null
+
+	case "$ID" in
+		rhel|centos)
+			[ ${VERSION_ID%.*} -lt 7 ] && echo ntp || echo chrony
+			;;
+		*)
+			echo chrony
+			;;
+	esac
+}
+
+current_ntp_providers=$(get_current_ntp_providers)
+
+case $(echo -n "$current_ntp_providers" | wc -w) in
+	0)
+		ntp_provider=$(get_default_ntp_provider)
+		;;
+	1)
+		ntp_provider=$current_ntp_providers
+		;;
+	*)
+		ntp_provider=""
+		error_message="Multiple NTP providers are currently active/enabled."
+		;;
+esac
+
+if [ -n "$ntp_provider" ]; then
+	printf '{"ansible_facts": {"ntp_provider": "%s"}}' "$ntp_provider"
+else
+	printf '{"failed": "True", "msg": "%s"}' "$error_message"
+fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,7 @@
   when: sync_mode is not defined
 
 - name: Select NTP provider
-  set_fact:
-    ntp_provider: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare('7.0', '<') else 'chrony' }}"
+  timesync_provider:
   when: sync_mode != 2 and (ntp_provider is not defined or ntp_provider == '')
 
 - name: Install chrony

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,10 +15,10 @@
     sync_mode: 3
   when: sync_mode is not defined
 
-- name: Select NTP implementation
+- name: Select NTP provider
   set_fact:
     ntp_provider: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare('7.0', '<') else 'chrony' }}"
-  when: sync_mode != 2
+  when: sync_mode != 2 and (ntp_provider is not defined or ntp_provider == '')
 
 - name: Install chrony
   package: name=chrony state=present

--- a/tests/tests_ntp_clean.yml
+++ b/tests/tests_ntp_clean.yml
@@ -1,0 +1,44 @@
+
+- name: Configure time synchronization with NTP servers and no installed providers
+  hosts: all
+  vars:
+    ntp_servers:
+      - hostname: 172.16.123.1
+      - hostname: 172.16.123.2
+        iburst: yes
+        minpoll: 4
+      - hostname: 172.16.123.3
+        pool: yes
+        iburst: yes
+        minpoll: 4
+        maxpoll: 6
+    clock_step_threshold: 0.01
+    dhcp_ntp_servers: yes
+    min_time_sources: 2
+  roles:
+    - timesync
+
+  pre_tasks:
+    - name: Remove NTP providers
+      package: name={{ item }} state=absent
+      with_items:
+        - chrony
+        - ntp
+
+  tasks:
+    - meta: flush_handlers
+
+    - name: Wait for services to start
+      wait_for:
+        timeout: 2
+
+    - name: Get list of currently used time sources
+      shell: chronyc -n sources || ntpq -pn
+      register: sources
+
+    - name: Check time sources
+      assert:
+        that:
+          - "'172.16.123.1' in sources.stdout"
+          - "'172.16.123.2' in sources.stdout"
+          - "'172.16.123.3' in sources.stdout"


### PR DESCRIPTION
This uses a simple module written in shell for selecting the provider by currently active/enabled service, or falling back to the system-specific provider. The user can override the selection by setting the ntp_provider variable.