### PR TITLE
 Add empty timesync_ntp_provider to defaults 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ timesync_ptp_domains: []
 timesync_dhcp_ntp_servers: false
 timesync_step_threshold: -1.0
 timesync_min_sources: 1
+timesync_ntp_provider: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,12 +17,12 @@
 
 - name: Determine current NTP provider
   timesync_provider:
-  when: timesync_mode != 2 and (timesync_ntp_provider is not defined or timesync_ntp_provider == '')
+  when: timesync_mode != 2 and timesync_ntp_provider == ''
 
 - name: Select NTP provider
   set_fact:
     timesync_ntp_provider: "{{ timesync_ntp_provider_os_default if timesync_ntp_provider_current == '' else timesync_ntp_provider_current }}"
-  when: timesync_mode != 2 and (timesync_ntp_provider is not defined or timesync_ntp_provider == '')
+  when: timesync_mode != 2 and timesync_ntp_provider == ''
 
 - name: Install chrony
   package:


### PR DESCRIPTION
Set the variable in defaults/main.yml to an empty string, so all input variables of the role are included there.

This PR includes #14 to avoid merge conflicts.