### PR TITLE
Rename timesync_ntp_provider_default to timesync_ntp_provider_os_default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Select NTP provider
   set_fact:
-    timesync_ntp_provider: "{{ timesync_ntp_provider_default if timesync_ntp_provider_current == '' else timesync_ntp_provider_current }}"
+    timesync_ntp_provider: "{{ timesync_ntp_provider_os_default if timesync_ntp_provider_current == '' else timesync_ntp_provider_current }}"
   when: timesync_mode != 2 and (timesync_ntp_provider is not defined or timesync_ntp_provider == '')
 
 - name: Install chrony

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,1 @@
-timesync_ntp_provider_default: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare('7.0', '<') else 'chrony' }}"
+timesync_ntp_provider_os_default: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare('7.0', '<') else 'chrony' }}"


### PR DESCRIPTION
for consistency with network, see https://github.com/linux-system-roles/network/issues/71