### PR TITLE
Use `is version` instead of `|version_compare`

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -25,7 +25,7 @@ minsources {{ timesync_min_sources }}
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift
 
-{% if timesync_chrony_version.stdout|version_compare('2.0', '<') %}
+{% if timesync_chrony_version.stdout is version('2.0', '<') %}
 # Decrease weight of stratum in source selection.
 stratumweight 0.001
 
@@ -34,7 +34,7 @@ bindcmdaddress 127.0.0.1
 bindcmdaddress ::1
 
 {% endif %}
-{% if timesync_chrony_version.stdout|version_compare('2.2', '<') %}
+{% if timesync_chrony_version.stdout is version('2.2', '<') %}
 # Specify file containing keys for NTP and command authentication.
 keyfile /etc/chrony.keys
 

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -13,7 +13,7 @@ driftfile /var/lib/ntp/drift
 # Permit time synchronization with our time source, but do not
 # permit the source to query or modify the service on this system.
 restrict default nomodify notrap nopeer noquery
-{% if timesync_ntp_version.stdout|version_compare('4.2.6', '<') %}
+{% if timesync_ntp_version.stdout is version('4.2.6', '<') %}
 restrict -6 default nomodify notrap nopeer noquery
 {% endif %}
 

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -27,7 +27,7 @@ includefile /etc/ntp.conf
 
 [chronyd]
 path /usr/sbin/chronyd
-{% if timesync_ntp_provider == 'chrony' and timesync_chrony_version.stdout|version_compare('1.30', '<') %}
+{% if timesync_ntp_provider == 'chrony' and timesync_chrony_version.stdout is version('1.30', '<') %}
 options -u chrony
 {% endif %}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,1 @@
-timesync_ntp_provider_os_default: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version|version_compare('7.0', '<') else 'chrony' }}"
+timesync_ntp_provider_os_default: "{{ 'ntp' if ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version is version('7.0', '<') else 'chrony' }}"


### PR DESCRIPTION
Using tests as filters is deprecated and `version_compare` was renamed
to `version` in Ansible 2.5.