### PR TITLE
Fix yamllint error

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,12 +1,28 @@
 galaxy_info:
   author: Miroslav Lichvar <mlichvar@redhat.com>
   description: Configure NTP and/or PTP
-  galaxy_tags: [ 'system', 'time', 'redhat', 'rhel', 'fedora', 'centos', 'ntp', 'ntpd', 'chrony', 'ptp' ]
+  galaxy_tags:
+    - system
+    - time
+    - redhat
+    - rhel
+    - fedora
+    - centos
+    - ntp
+    - ntpd
+    - chrony
+    - ptp
   company: Red Hat, Inc.
   license: MIT
   min_ansible_version: 2.4
   platforms:
-  - name: Fedora
-    versions: [ 27, 28 ]
-  - name: EL
-    versions: [ 6, 7 ]
+    - name: Fedora
+      versions:
+        - 28
+        - 29
+        - 30
+    - name: EL
+      versions:
+        - 6
+        - 7
+        - 8


### PR DESCRIPTION
Fixes indentation in role's metadata:
--> Executing Yamllint on files found in timesync/...
    timesync/meta/main.yml
      9:3       error    wrong indentation: expected 4 but found 2  (indentation)