### PR TITLE
Add hybrid_e2e option to PTP domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ timesync_ptp_domains:
                                 # (default UDPv4)
     udp_ttl: 1                  # TTL for UDPv4 and UDPv6 transports
                                 # (default 1)
+    hybrid_e2e: no              # Flag enabling unicast end-to-end delay
+                                # requests (default no)
 
 # Flag enabling use of NTP servers provided by DHCP (default no)
 timesync_dhcp_ntp_servers: no

--- a/templates/ptp4l.conf.j2
+++ b/templates/ptp4l.conf.j2
@@ -10,6 +10,9 @@ network_transport	{{ timesync_ptp_domains[0]['transport'] }}
 {% if 'udp_ttl' in timesync_ptp_domains[0] %}
 udp_ttl			{{ timesync_ptp_domains[0]['udp_ttl'] }}
 {% endif %}
+{% if 'hybrid_e2e' in timesync_ptp_domains[0] and timesync_ptp_domains[0]['hybrid_e2e'] %}
+hybrid_e2e		1
+{% endif %}
 {% if not timesync_mode2_hwts and timesync_step_threshold >= 0.0 %}
 first_step_threshold	{{ timesync_step_threshold }}
 {% endif %}

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -12,6 +12,9 @@ ptp4l_option network_transport {{ value['transport'] }}
 {% if 'udp_ttl' in value %}
 ptp4l_option udp_ttl {{ value['udp_ttl'] }}
 {% endif %}
+{% if 'hybrid_e2e' in value and value['hybrid_e2e'] %}
+ptp4l_option hybrid_e2e 1
+{% endif %}
 
 {% endfor %}
 [timemaster]

--- a/tests/tests_ptp_multi.yml
+++ b/tests/tests_ptp_multi.yml
@@ -9,6 +9,7 @@
         interfaces: "{{ [ ansible_default_ipv4['interface'] ] }}"
         delay: 0.001
         transport: UDPv4
+        hybrid_e2e: yes
         udp_ttl: 2
     timesync_step_threshold: 0.0001
     timesync_min_sources: 2


### PR DESCRIPTION
The hybrid_e2e option configures the PTP slave to send delay
requests to the unicast address of the master. This may reduce the
amount of PTP traffic in large networks.