### PR TITLE
Remove ignore_errors for Disable services tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Set version specific variables
   include_vars: "{{ lookup('first_found', ffparams) }}"
   vars:
@@ -12,6 +13,22 @@
         - "default.yml"
       paths:
         - "{{ role_path }}/vars"
+
+- name: Get services list using platform specific services manager
+  include_tasks: "{{ lookup('first_found', __timesync_ff_params) }}"
+  vars:
+    __timesync_ff_params:
+      files:
+        - "{{ ansible_facts['distribution'] ~ '_' ~
+              ansible_facts['distribution_major_version'] }}.yml"
+        - "default.yml"
+      paths:
+        - "{{ role_path }}/tasks/setup"
+
+- name: Check that variable 'timesync_services' is defined
+  assert:
+    that: timesync_services is defined
+    fail_msg: "Variable 'timesync_services' is not defined"
 
 - name: Check if only NTP is needed
   set_fact:
@@ -196,54 +213,59 @@
     name: chronyd
     state: stopped
     enabled: false
-  when: timesync_mode != 1 or timesync_ntp_provider != 'chrony'
-  ignore_errors: true
+  when:
+    - timesync_mode != 1 or timesync_ntp_provider != 'chrony'
+    - "'chronyd' in timesync_services"
 
 - name: Disable ntpd
   service:
     name: ntpd
     state: stopped
     enabled: false
-  when: timesync_mode != 1 or timesync_ntp_provider != 'ntp'
-  ignore_errors: true
+  when:
+    - timesync_mode != 1 or timesync_ntp_provider != 'ntp'
+    - "'ntpd' in timesync_services"
 
 - name: Disable ntpdate
   service:
     name: ntpdate
     state: stopped
     enabled: false
-  ignore_errors: true
+  when: "'ntpdate' in timesync_services"
 
 - name: Disable sntp
   service:
     name: sntp
     state: stopped
     enabled: false
-  ignore_errors: true
+  when: "'sntp' in timesync_services"
 
 - name: Disable ptp4l
   service:
     name: ptp4l
     state: stopped
     enabled: false
-  when: timesync_mode != 2
-  ignore_errors: true
+  when:
+    - timesync_mode != 2
+    - "'ptp4l' in timesync_services"
 
 - name: Disable phc2sys
   service:
     name: phc2sys
     state: stopped
     enabled: false
-  when: timesync_mode != 2 or not timesync_mode2_hwts
-  ignore_errors: true
+  when:
+    - timesync_mode != 2 or not timesync_mode2_hwts
+    - "'phc2sys' in timesync_services"
 
 - name: Disable timemaster
   service:
     name: timemaster
     state: stopped
     enabled: false
-  when: timesync_mode != 3
-  ignore_errors: true
+  when:
+    - timesync_mode != 3
+    - "'timemaster' in timesync_services"
 
 - name: Enable chronyd
   service:

--- a/tasks/setup/CentOS_6.yml
+++ b/tasks/setup/CentOS_6.yml
@@ -1,0 +1,15 @@
+---
+- name: Set variable with services List for CentOS 6
+  command: chkconfig --list  # noqa 303
+  register: __timesync_register_services
+  check_mode: no
+  changed_when: false
+
+- name: Set variable `timesync_services` with filtered uniq service names
+  set_fact:
+    timesync_services: |
+      {{ __timesync_register_services.stdout_lines |
+          map('regex_replace', '[ \t].*$', '') |
+          unique |
+          list }}
+  when: __timesync_register_services is defined

--- a/tasks/setup/RedHat_6.yml
+++ b/tasks/setup/RedHat_6.yml
@@ -1,0 +1,15 @@
+---
+- name: Set variable with services List for RedHat 6
+  command: chkconfig --list  # noqa 303
+  register: __timesync_register_services
+  check_mode: no
+  changed_when: false
+
+- name: Set variable `timesync_services` with filtered uniq service names
+  set_fact:
+    timesync_services: |
+      {{ __timesync_register_services.stdout_lines |
+          map('regex_replace', '[ \t].*$', '') |
+          unique |
+          list }}
+  when: __timesync_register_services is defined

--- a/tasks/setup/default.yml
+++ b/tasks/setup/default.yml
@@ -1,0 +1,16 @@
+---
+- name: Set variable with services List for RedHat 7 and above systems
+  command: systemctl list-unit-files --no-legend *.service  # noqa 303
+  register: __timesync_register_services
+  check_mode: no
+  changed_when: false
+
+- name: Set variable `timesync_services` with filtered uniq service names
+  set_fact:
+    timesync_services: |
+      {{ __timesync_register_services.stdout_lines |
+          map('regex_replace', '[.]service.*$', '') |
+          map('regex_replace', '@$', '') |
+          unique |
+          list }}
+  when: __timesync_register_services is defined


### PR DESCRIPTION
Currently, we have errors, like these during execution role:
```
TASK [timesync : Disable ntpd] *************************************************************************************************************************************************************
fatal: [host1]: FAILED! => changed=false 
  msg: 'Could not find the requested service ntpd: host'
...ignoring
fatal: [host2]: FAILED! => changed=false 
  msg: 'Could not find the requested service ntpd: host'
...ignoring

TASK [timesync : Disable ntpdate] **********************************************************************************************************************************************************
fatal: [host1]: FAILED! => changed=false 
  msg: 'Could not find the requested service ntpdate: host'
...ignoring
fatal: [host2]: FAILED! => changed=false 
  msg: 'Could not find the requested service ntpdate: host'
...ignoring
```

To prevent errors was added additional service existing check .