### PR TITLE
Fix package versions

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 __timesync_chrony_version: "{{
-  ansible_facts.packages['chrony'][0].version|default('')|int
-  if 'chrony' in ansible_facts.packages else 0.0 }}"
+  ansible_facts.packages['chrony'][0].version|default('0')
+  if 'chrony' in ansible_facts.packages else '0' }}"
 __timesync_ntp_version: "{{
-  ansible_facts.packages['ntp'][0].version|default('')|int
-  if 'ntp' in ansible_facts.packages else 0.0 }}"
+  ansible_facts.packages['ntp'][0].version|default('0')
+  if 'ntp' in ansible_facts.packages else '0' }}"


### PR DESCRIPTION
Don't convert the version of chrony and ntp to int to not lose the
minor number after the dot.