### PR TITLE
Add support for HW timestamping with NTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ timesync_max_distance: 0
 # of the clock (default 1)
 timesync_min_sources: 1
 
+# List of interfaces which should have hardware timestamping enabled for NTP
+# (default empty list). As a special value, '*' enables the timestamping on all
+# interfaces that support it.
+timesync_ntp_hwts_interfaces: [ '*' ]
+
 # Name of the package which should be installed and configured for NTP.
 # Possible values are "chrony" and "ntp". If not defined, the currently active
 # or enabled service will be configured. If no service is active or enabled, a

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ timesync_ntp_servers:
     pool: no                    # Flag indicating that each resolved address
                                 # of the hostname is a separate NTP server
                                 # (default no)
+    xleave: no                  # Flag enabling interleaved mode (default no)
 
 # List of PTP domains
 timesync_ptp_domains:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ timesync_ntp_servers:
                                 # of the hostname is a separate NTP server
                                 # (default no)
     xleave: no                  # Flag enabling interleaved mode (default no)
+    filter: 1                   # Number of NTP measurements per clock update
+                                # (default 1)
 
 # List of PTP domains
 timesync_ptp_domains:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,6 @@ timesync_ptp_domains: []
 timesync_dhcp_ntp_servers: false
 timesync_step_threshold: -1.0
 timesync_min_sources: 1
+timesync_ntp_hwts_interfaces: []
 timesync_ntp_provider: ''
 timesync_max_distance: 0

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -26,6 +26,17 @@ makestep {{ timesync_step_threshold if timesync_step_threshold > 0.0 else '1.0' 
 # Enable kernel synchronization of the real-time clock (RTC).
 rtcsync
 
+{% if __timesync_chrony_version is version('3.0', '>=') and
+        timesync_ntp_hwts_interfaces|length > 0 %}
+# Enable hardware timestamping.
+{% for interface in timesync_ntp_hwts_interfaces %}
+hwtimestamp {{ interface }}{% if __timesync_chrony_version is version('3.1', '>=') %}
+ minpoll {{ (timesync_ntp_servers | rejectattr('minpoll', 'undefined') |
+             map(attribute='minpoll') | list + [0]) | min }}{% endif %}
+
+{% endfor %}
+
+{% endif %}
 {% if timesync_min_sources > 1 %}
 # Increase the minimum number of selectable sources required to adjust
 # the system clock.

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -5,7 +5,9 @@
 value['hostname'] }}{{
 ' minpoll {0}'.format(value['minpoll']) if 'minpoll' in value else '' }}{{
 ' maxpoll {0}'.format(value['maxpoll']) if 'maxpoll' in value else '' }}{{
-' iburst' if 'iburst' in value and value else '' }}
+' iburst' if 'iburst' in value and value else '' }}{{
+' xleave' if __timesync_chrony_version is version('3.0', '>=') and
+        'xleave' in value and value['xleave'] else '' }}
 {% endfor %}
 
 {% if timesync_dhcp_ntp_servers and timesync_chrony_dhcp_sourcedir %}

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -7,7 +7,10 @@ value['hostname'] }}{{
 ' maxpoll {0}'.format(value['maxpoll']) if 'maxpoll' in value else '' }}{{
 ' iburst' if 'iburst' in value and value else '' }}{{
 ' xleave' if __timesync_chrony_version is version('3.0', '>=') and
-        'xleave' in value and value['xleave'] else '' }}
+        'xleave' in value and value['xleave'] else '' }}{{
+' filter {0}'.format(value['filter'])
+        if __timesync_chrony_version is version('3.4', '>=') and
+                'filter' in value and value['filter'] > 1 else '' }}
 {% endfor %}
 
 {% if timesync_dhcp_ntp_servers and timesync_chrony_dhcp_sourcedir %}

--- a/tests/tests_ntp.yml
+++ b/tests/tests_ntp.yml
@@ -16,6 +16,7 @@
     timesync_step_threshold: 0.01
     timesync_dhcp_ntp_servers: yes
     timesync_min_sources: 2
+    timesync_ntp_hwts_interfaces: [ '*' ]
   roles:
     - linux-system-roles.timesync
 
@@ -60,5 +61,9 @@
               - chrony_conf is not search('172\.16\.123\.2.*filter')
               - chrony_conf is search('172\.16\.123\.3.*filter 3') ==
                 __timesync_chrony_version is version('3.4', '>=')
+              - chrony_conf is search('hwtimestamp \*') ==
+                __timesync_chrony_version is version('3.0', '>=')
+              - chrony_conf is search('hwtimestamp .* minpoll 0') ==
+                __timesync_chrony_version is version('3.1', '>=')
           when: chrony_conf is defined
       tags: tests::verify

--- a/tests/tests_ntp.yml
+++ b/tests/tests_ntp.yml
@@ -11,6 +11,7 @@
         iburst: yes
         minpoll: 4
         maxpoll: 6
+        xleave: yes
     timesync_step_threshold: 0.01
     timesync_dhcp_ntp_servers: yes
     timesync_min_sources: 2
@@ -35,4 +36,24 @@
               - "'172.16.123.1' in sources.stdout"
               - "'172.16.123.2' in sources.stdout"
               - "'172.16.123.3' in sources.stdout"
+
+        - name: Fetch chrony.conf file
+          slurp:
+            src: /etc/chrony.conf
+          when: "'LastRx' in sources.stdout"
+          register: chrony_conf_encoded
+
+        - name: Decode chrony.conf file
+          set_fact:
+            chrony_conf: "{{ chrony_conf_encoded.content | b64decode }}"
+          when: chrony_conf_encoded is not skipped
+
+        - name: Check chrony.conf file
+          assert:
+            that:
+              - chrony_conf is not search('172\.16\.123\.1.*xleave')
+              - chrony_conf is not search('172\.16\.123\.2.*xleave')
+              - chrony_conf is search('172\.16\.123\.3.*xleave') ==
+                __timesync_chrony_version is version('3.0', '>=')
+          when: chrony_conf is defined
       tags: tests::verify

--- a/tests/tests_ntp.yml
+++ b/tests/tests_ntp.yml
@@ -12,6 +12,7 @@
         minpoll: 4
         maxpoll: 6
         xleave: yes
+        filter: 3
     timesync_step_threshold: 0.01
     timesync_dhcp_ntp_servers: yes
     timesync_min_sources: 2
@@ -55,5 +56,9 @@
               - chrony_conf is not search('172\.16\.123\.2.*xleave')
               - chrony_conf is search('172\.16\.123\.3.*xleave') ==
                 __timesync_chrony_version is version('3.0', '>=')
+              - chrony_conf is not search('172\.16\.123\.1.*filter')
+              - chrony_conf is not search('172\.16\.123\.2.*filter')
+              - chrony_conf is search('172\.16\.123\.3.*filter 3') ==
+                __timesync_chrony_version is version('3.4', '>=')
           when: chrony_conf is defined
       tags: tests::verify


### PR DESCRIPTION
This PR adds options to enable NTP HW timestamping on specified interfaces, enable the interleaved mode and sample filtering in order to enable highly accurate and stable synchronization in local network.