### PR TITLE
Add option to configure max distance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ timesync_dhcp_ntp_servers: no
 # Zero threshold disables all steps.
 timesync_step_threshold: 1.0
 
+# Maximum root distance to accept measurements from NTP servers
+# Set to 0 to use provider default
+timesync_max_distance: 0
+
 # Minimum number of selectable time sources required to allow synchronization
 # of the clock (default 1)
 timesync_min_sources: 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ timesync_dhcp_ntp_servers: false
 timesync_step_threshold: -1.0
 timesync_min_sources: 1
 timesync_ntp_provider: ''
+timesync_max_distance: 0

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -45,3 +45,8 @@ commandkey 1
 generatecommandkey
 
 {% endif %}
+{% if timesync_max_distance != 0 %}
+# Limit maximum root distance.
+maxdistance {{ timesync_max_distance }}
+
+{% endif %}

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -34,3 +34,8 @@ tinker step {{ timesync_step_threshold }}
 tos minsane {{ timesync_min_sources }}
 
 {% endif %}
+{% if timesync_max_distance != 0 %}
+# Limit maximum root distance.
+tos maxdist {{ timesync_max_distance }}
+
+{% endif %}


### PR DESCRIPTION
This PR adds the ability to configure the Max Distance parameter for Chrony and NTP. This will allow, among others, to sync Linux clients to a Windows NTP server.