### PR TITLE
Support chrony configuration in Fedora 33

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -8,6 +8,11 @@ value['hostname'] }}{{
 ' iburst' if 'iburst' in value and value else '' }}
 {% endfor %}
 
+{% if timesync_dhcp_ntp_servers and timesync_chrony_dhcp_sourcedir %}
+# Use NTP servers from DHCP.
+sourcedir {{ timesync_chrony_dhcp_sourcedir }}
+
+{% endif %}
 {% if timesync_step_threshold != 0.0 %}
 # Allow the system clock to be stepped in the first three updates.
 makestep {{ timesync_step_threshold if timesync_step_threshold > 0.0 else '1.0' }} 3

--- a/vars/CentOS_6.yml
+++ b/vars/CentOS_6.yml
@@ -1,1 +1,2 @@
 timesync_ntp_provider_os_default: "ntp"
+timesync_chrony_dhcp_sourcedir: ""

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -1,0 +1,2 @@
+timesync_ntp_provider_os_default: "chrony"
+timesync_chrony_dhcp_sourcedir: "/run/chrony-dhcp"

--- a/vars/Fedora_33.yml
+++ b/vars/Fedora_33.yml
@@ -1,0 +1,2 @@
+timesync_ntp_provider_os_default: "chrony"
+timesync_chrony_dhcp_sourcedir: "/run/chrony-dhcp"

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -1,1 +1,2 @@
 timesync_ntp_provider_os_default: "ntp"
+timesync_chrony_dhcp_sourcedir: ""

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -1,0 +1,2 @@
+timesync_ntp_provider_os_default: "chrony"
+timesync_chrony_dhcp_sourcedir: "/run/chrony-dhcp"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,1 +1,2 @@
 timesync_ntp_provider_os_default: "chrony"
+timesync_chrony_dhcp_sourcedir: ""


### PR DESCRIPTION
The chrony package in Fedora 33 changed configuration of NTP servers
from DHCP. Instead of relaying on a separate helper script, the sources
are now loaded directly from /run/chrony-dhcp.

This depends on #87.