### PR TITLE
[WIP] Implement idempotency & checkmode testing

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+
+- src: https://github.com/i386x/meta_test
+  version: ic-role
+  name: linux-system-roles.meta_test

--- a/tests/tests_ntp.yml
+++ b/tests/tests_ntp.yml
@@ -1,6 +1,11 @@
 - name: Configure time synchronization with NTP servers
   hosts: all
   vars:
+    meta_test_scenario:
+      name: wrap_role
+      role_name: linux-system-roles.timesync
+      test_checkmode: "{{ test_checkmode | d(False) }}"
+      test_idempotency: "{{ test_idempotency | d(False) }}"
     timesync_ntp_servers:
       - hostname: 172.16.123.1
       - hostname: 172.16.123.2
@@ -17,10 +22,12 @@
     timesync_dhcp_ntp_servers: yes
     timesync_min_sources: 2
     timesync_ntp_hwts_interfaces: [ '*' ]
-  roles:
-    - linux-system-roles.timesync
 
   tasks:
+    - name: Import linux-system-roles.meta_test role
+      import_role:
+        name: linux-system-roles.meta_test
+
     - block:
         - meta: flush_handlers
 

--- a/tests/tests_ntp_checkmode.yml
+++ b/tests/tests_ntp_checkmode.yml
@@ -1,0 +1,3 @@
+- import_playbook: tests_ntp.yml
+  vars:
+    test_checkmode: yes

--- a/tests/tests_ntp_idempotency.yml
+++ b/tests/tests_ntp_idempotency.yml
@@ -1,0 +1,3 @@
+- import_playbook: tests_ntp.yml
+  vars:
+    test_idempotency: yes


### PR DESCRIPTION
Use `linux-system-roles.meta_test` role to implement idempotency and checkmode testing.