### PR TITLE
use public: true to expose role parameters; ansible 2.8

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
     - ptp
   company: Red Hat, Inc.
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: 2.8
   platforms:
     - name: Fedora
       versions:

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -2,18 +2,20 @@
   hosts: all
 
   tasks:
-    - block:
-        - import_role:
-            name: linux-system-roles.timesync
-          when: false
+    - name: include the timesync role
+      include_role:
+        name: linux-system-roles.timesync
+        public: true
 
-        - assert:
-            that: "vars[item] is defined"
-          loop:
-            - timesync_ntp_servers
-            - timesync_ptp_domains
-            - timesync_dhcp_ntp_servers
-            - timesync_step_threshold
-            - timesync_min_sources
-            - timesync_ntp_provider
-      when: "ansible_version.full is version_compare('2.7', '>=')"
+    - name: check that public vars are defined
+      assert:
+        that: vars[item] is defined
+      loop:
+        - timesync_ntp_servers
+        - timesync_ptp_domains
+        - timesync_dhcp_ntp_servers
+        - timesync_step_threshold
+        - timesync_min_sources
+        - timesync_ntp_hwts_interfaces
+        - timesync_ntp_provider
+        - timesync_max_distance


### PR DESCRIPTION
Use `include_role` with `public: true` to expose role parameters
for testing.
Update `min_ansible_version` to 2.8.