### PR TITLE
RHELPLAN-68118 - Collections - Timesync - fixing ansible-test errors

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.1"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.3.0"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev
@@ -36,7 +36,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection,ansible-test" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -1,0 +1,1 @@
+plugins/modules/timesync_provider.sh shebang


### PR DESCRIPTION
- Add .sanity-ansible-ignore-2.10.txt
- Use tox-lsr 2.3.0 and enable ansible-test