### PR TITLE
Cleaning up ansible-lint errors except 301 and 303.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,10 +1,3 @@
 ---
 skip_list:
-- '106'
-- '208'
-- '301'  # Commands should not change things if nothing needs doing
 - '305'  # Use shell only when shell functionality is required
-- '306'
-- '403'
-- '502'
-- '602'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
   timesync_provider:
   when:
     - timesync_mode != 2
-    - timesync_ntp_provider == ''
+    - timesync_ntp_provider | length == 0
 
 - name: Select NTP provider
   set_fact:
@@ -62,7 +62,7 @@
         default(timesync_ntp_provider_os_default, true) }}"
   when:
     - timesync_mode != 2
-    - timesync_ntp_provider == ''
+    - timesync_ntp_provider | length == 0
 
 - name: Install chrony
   package:

--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -12,6 +12,7 @@
       template:
         src: inventory.yaml.j2
         dest: "{{ tempinventory.path }}"
+        mode: '0644'
       delegate_to: localhost
 
 - name: Run tests_default.yml normally
@@ -23,6 +24,7 @@
     - name: Run ansible-playbook with tests_default.yml in check mode
       # yamllint disable-line rule:line-length
       command: ansible-playbook -vvv -i {{ tempinventory.path }} --check tests_default.yml
+      changed_when: false
       delegate_to: localhost
 
     - name: remove the temporary file

--- a/tests/tests_ntp_provider6.yml
+++ b/tests/tests_ntp_provider6.yml
@@ -19,7 +19,8 @@
         # meta doesn't pickup with_item in when conditional,
         # following set_fact workarounds that
         # see https://github.com/ansible/ansible/issues/35890
-        - set_fact:
+        - name: Set the availability of both NTP providers
+          set_fact:
             both_avail: false
           when: item.failed
           with_items:


### PR DESCRIPTION
- '301'  # Commands should not change things if nothing needs doing
- '305'  # Use shell only when shell functionality is required