### PR TITLE
Update timestamping checks using ethtool

### DIFF
--- a/tests/tests_ntp_ptp.yml
+++ b/tests/tests_ntp_ptp.yml
@@ -48,5 +48,5 @@
                   - "'PTP0' in sources.stdout"
                   - "'PTP1' in sources.stdout"
 
-          when: "'SOF_TIMESTAMPING_TX_' in ethtool.stdout"
+          when: "'ware-transmit' in ethtool.stdout"
       tags: tests::verify

--- a/tests/tests_ptp_multi.yml
+++ b/tests/tests_ptp_multi.yml
@@ -77,5 +77,5 @@
                 - ansible_distribution not in ['RedHat', 'CentOS'] or
                   ansible_distribution_version is not version('8.3', '<')
 
-          when: "'SOF_TIMESTAMPING_TX_' in ethtool.stdout"
+          when: "'ware-transmit' in ethtool.stdout"
       tags: tests::verify

--- a/tests/tests_ptp_single.yml
+++ b/tests/tests_ptp_single.yml
@@ -39,5 +39,5 @@
                 - ansible_distribution not in ['RedHat', 'CentOS'] or
                   ansible_distribution_version is not version('8.3', '<')
 
-          when: "'SOF_TIMESTAMPING_TX_' in ethtool.stdout"
+          when: "'ware-transmit' in ethtool.stdout"
       tags: tests::verify


### PR DESCRIPTION
New ethtool versions don't print the upper-case timestamping constants
anymore. Match the lower-case strings instead.