### PR TITLE
evaluate is_ntp_default as boolean, not string

### DIFF
--- a/tests/tests_ntp_provider6.yml
+++ b/tests/tests_ntp_provider6.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     # yamllint disable-line rule:line-length
-    is_ntp_default: "ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version is version('7.0', '<')"
+    is_ntp_default: "{{ ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_version is version('7.0', '<') }}"
     both_avail: true
 
   tasks:


### PR DESCRIPTION
I guess earlier versions of Ansible would evaluate this string as
a jinja2 expression when evauluated in a `when` or other conditional
context, but in Ansible 2.12, it gets evaluated as a string.  Ensure
that the evaluation into a boolean happens at variable assignment
time.