### PR TITLE
Fix an issue if a service is listed by service_facts that does not have the 'status' property defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     timesync_services: "{{ ansible_facts.services.values() |
           selectattr('name', 'defined') |
-          selectattr('status', 'defined') |
+          rejectattr('status', 'undefined') |
           rejectattr('status', 'match', '^not-found$') |
           rejectattr('status', 'match', '^masked$') |
           rejectattr('status', 'match', '^failed$') |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
   set_fact:
     timesync_services: "{{ ansible_facts.services.values() |
           selectattr('name', 'defined') |
+          selectattr('status', 'defined') |
           rejectattr('status', 'match', '^not-found$') |
           rejectattr('status', 'match', '^masked$') |
           rejectattr('status', 'match', '^failed$') |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   set_fact:
     timesync_services: "{{ ansible_facts.services.values() |
           selectattr('name', 'defined') |
-          rejectattr('status', 'undefined') |
+          selectattr('status', 'defined') |
           rejectattr('status', 'match', '^not-found$') |
           rejectattr('status', 'match', '^masked$') |
           rejectattr('status', 'match', '^failed$') |


### PR DESCRIPTION
When running this role I on a Debian ran into an issue where the ```service_facts``` module reports a bunch of things which have no ```status``` and breaks the subsequent task.

This PR will filter out such ```services```.