### PR TITLE
handle errors with stopping services

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -226,6 +226,11 @@
   when:
     - timesync_mode != 1 or timesync_ntp_provider != 'chrony'
     - "'chronyd' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service chronyd:')
 
 - name: Disable ntpd
   service:
@@ -235,6 +240,11 @@
   when:
     - timesync_mode != 1 or timesync_ntp_provider != 'ntp'
     - "'ntpd' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service ntpd:')
 
 - name: Disable ntpdate
   service:
@@ -242,6 +252,11 @@
     state: stopped
     enabled: false
   when: "'ntpdate' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service ntpdate:')
 
 - name: Disable sntp
   service:
@@ -249,6 +264,11 @@
     state: stopped
     enabled: false
   when: "'sntp' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service sntp:')
 
 - name: Disable ptp4l
   service:
@@ -258,6 +278,11 @@
   when:
     - timesync_mode != 2
     - "'ptp4l' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service ptp4l:')
 
 - name: Disable phc2sys
   service:
@@ -267,6 +292,11 @@
   when:
     - timesync_mode != 2 or not timesync_mode2_hwts
     - "'phc2sys' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service phc2sys:')
 
 - name: Disable timemaster
   service:
@@ -276,6 +306,11 @@
   when:
     - timesync_mode != 3
     - "'timemaster' in timesync_services"
+  register: __disable_result
+  failed_when:
+    - __disable_result is failed
+    - not __disable_result.msg is match(
+      'Could not find the requested service timemaster:')
 
 - name: Enable chronyd
   service:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2058645
Not sure if it is a problem with rhel9 systemctl list-units, or a problem
with ansible-core 2.12 parsing that output, but service_facts reports
that ptp4l is a valid service, and the service module reports an error
trying to use state: stopped.  For example, here is the corresponding
systemctl status ptp4l when service_facts reports a valid service:
`Failed to get properties: Access denied`
Here is the systemctl list-units output
```
  ptp4l.service                          loaded    inactive dead    Precision Time Protocol (PTP) service
```
Here is the service_fact:
```
    "ptp4l.service": {
        "name": "ptp4l.service",
        "source": "systemd",
        "state": "stopped",
        "status": "inactive"
    },
```

The fix is to check the result of the `state: stopped` task.  If it is
a failure, but the MSG is `Could not find the requested service NAME`,
then ignore the failure.