### PR TITLE
support gather_facts: false; support setup-snapshot.yml (#52)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 - name: Set version specific variables
-  include_vars: "{{ lookup('first_found', ffparams) }}"
-  vars:
-    ffparams:
-      files:
-        - "{{ ansible_facts['distribution'] }}_\
-          {{ ansible_facts['distribution_version'] }}.yml"
-        - "{{ ansible_facts['distribution'] }}_\
-          {{ ansible_facts['distribution_major_version'] }}.yml"
-        - "{{ ansible_facts['distribution'] }}.yml"
-        - "{{ ansible_facts['os_family'] }}.yml"
-        - "default.yml"
-      paths:
-        - "{{ role_path }}/vars"
+  include_tasks: tasks/set_vars.yml
 
 - name: Populate service facts
   service_facts:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__timesync_required_facts) == __timesync_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ lookup('first_found', ffparams) }}"
+  vars:
+    ffparams:
+      files:
+        - "{{ ansible_facts['distribution'] }}_\
+          {{ ansible_facts['distribution_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}_\
+          {{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
+        - "default.yml"
+      paths:
+        - "{{ role_path }}/vars"

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,26 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.timesync
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages to put them in the local cache
+      package:
+        name:
+          - chrony
+          - ntp
+          - linuxptp
+        state: present
+      no_log: true
+      ignore_errors: true
+
+    - name: Uninstall test packages
+      package:
+        name:
+          - chrony
+          - ntp
+          - linuxptp
+        state: absent
+      no_log: true

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -3,3 +3,4 @@
 
   roles:
     - linux-system-roles.timesync
+  gather_facts: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,3 +4,10 @@ __timesync_chrony_version: "{{
 __timesync_ntp_version: "{{
   ansible_facts.packages['ntp'][0].version|default('0')
   if 'ntp' in ansible_facts.packages else '0' }}"
+
+# ansible_facts required by the role
+__timesync_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.