### PR TITLE
WIP - add before, before suite, after, and after suite playbooks

### DIFF
--- a/tests/_after_test.yml
+++ b/tests/_after_test.yml
@@ -20,11 +20,15 @@
     - name: Restore services to correct state
       service:
         name: "{{ __item['name'] }}"
-        state: "{{ (__item['state'] == 'running') | ternary('restarted', 'stopped') }}"
+        state: "{{ (__item['state'] == 'running') |
+          ternary('restarted', 'stopped') }}"
         enabled: "{{ __item['status'] == 'enabled' }}"
       loop: "{{ __timesync_services }}"
       ignore_errors: true
       vars:
-        __system_services: "{{ __timesync_services_raw['content'] | b64decode | from_json }}"
-        __sys_item: "{{ __system_services | selectattr('name', 'match', '^' ~ item ~ '$') }}"
-        __item: "{{ __sys_item[0] if __sys_item else {'name': item, 'state': 'stopped', 'status': 'disabled'} }}"
+        __system_services: "{{ __timesync_services_raw['content'] |
+          b64decode | from_json }}"
+        __sys_item: "{{ __system_services |
+          selectattr('name', 'match', '^' ~ item ~ '$') }}"
+        __item: "{{ __sys_item[0] if __sys_item else
+          {'name': item, 'state': 'stopped', 'status': 'disabled'} }}"

--- a/tests/_after_test.yml
+++ b/tests/_after_test.yml
@@ -1,0 +1,30 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include test vars
+      include_vars: vars/main.yml
+
+    - name: Remove packages
+      package:
+        name: "{{ __timesync_packages }}"
+        state: absent
+
+    - name: Restore files modified by these role tests
+      command: tar xfP {{ __timesync_tar }}
+
+    - name: Read saved system services state
+      slurp:
+        src: "{{ __timesync_services_json }}"
+      register: __timesync_services_raw
+
+    - name: Restore services to correct state
+      service:
+        name: "{{ __item['name'] }}"
+        state: "{{ (__item['state'] == 'running') | ternary('restarted', 'stopped') }}"
+        enabled: "{{ __item['status'] == 'enabled' }}"
+      loop: "{{ __timesync_services }}"
+      ignore_errors: true
+      vars:
+        __system_services: "{{ __timesync_services_raw['content'] | b64decode | from_json }}"
+        __sys_item: "{{ __system_services | selectattr('name', 'match', '^' ~ item ~ '$') }}"
+        __item: "{{ __sys_item[0] if __sys_item else {'name': item, 'state': 'stopped', 'status': 'disabled'} }}"

--- a/tests/_after_test_suite.yml
+++ b/tests/_after_test_suite.yml
@@ -1,0 +1,13 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include test vars
+      include_vars: vars/main.yml
+
+    - name: Remove test files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ __timesync_tar }}"
+        - "{{ __timesync_services_json }}"

--- a/tests/_before_test_suite.yml
+++ b/tests/_before_test_suite.yml
@@ -1,0 +1,30 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Include test vars
+      include_vars: vars/main.yml
+
+    - name: Save files modified by role tests
+      command: tar cfP {{ __timesync_tar }} {{ __timesync_save_files | join(" ") }}
+      ignore_errors: true  # ignore missing files
+
+    - name: Get initial state of services
+      service_facts:
+
+    - name: Get timesync services states
+      set_fact:
+        __timesync_system_states: |
+          {% for ts_srv in __timesync_services %}
+          {% endfor %}
+
+    - name: Save service state
+      copy:
+        dest: "{{ __timesync_services_json }}"
+        content: "{{ __system_services | to_nice_json }}"
+        force: true
+      vars:
+        __system_services_suffix: "{{ ansible_facts.services.keys() | intersect(__timesync_services_suffix) |
+            map('extract', ansible_facts.services) | selectattr('status', 'match', '^(enabled|disabled)$') }}"
+        __system_services_nosuffix: "{{ ansible_facts.services.keys() | intersect(__timesync_services) |
+            map('extract', ansible_facts.services) | selectattr('status', 'match', '^(enabled|disabled)$') }}"
+        __system_services: "{{ __system_services_suffix + __system_services_nosuffix }}"

--- a/tests/_before_test_suite.yml
+++ b/tests/_before_test_suite.yml
@@ -5,7 +5,8 @@
       include_vars: vars/main.yml
 
     - name: Save files modified by role tests
-      command: tar cfP {{ __timesync_tar }} {{ __timesync_save_files | join(" ") }}
+      command: >
+        tar cfP {{ __timesync_tar }} {{ __timesync_save_files | join(" ") }}
       ignore_errors: true  # ignore missing files
 
     - name: Get initial state of services
@@ -23,8 +24,13 @@
         content: "{{ __system_services | to_nice_json }}"
         force: true
       vars:
-        __system_services_suffix: "{{ ansible_facts.services.keys() | intersect(__timesync_services_suffix) |
-            map('extract', ansible_facts.services) | selectattr('status', 'match', '^(enabled|disabled)$') }}"
-        __system_services_nosuffix: "{{ ansible_facts.services.keys() | intersect(__timesync_services) |
-            map('extract', ansible_facts.services) | selectattr('status', 'match', '^(enabled|disabled)$') }}"
-        __system_services: "{{ __system_services_suffix + __system_services_nosuffix }}"
+        __system_services_suffix: "{{ ansible_facts.services.keys() |
+          intersect(__timesync_services_suffix) |
+          map('extract', ansible_facts.services) |
+          selectattr('status', 'match', '^(enabled|disabled)$') }}"
+        __system_services_nosuffix: "{{ ansible_facts.services.keys() |
+          intersect(__timesync_services) |
+          map('extract', ansible_facts.services) |
+          selectattr('status', 'match', '^(enabled|disabled)$') }}"
+        __system_services: "{{ __system_services_suffix +
+          __system_services_nosuffix }}"

--- a/tests/vars/main.yml
+++ b/tests/vars/main.yml
@@ -1,0 +1,22 @@
+__timesync_save_files:
+  - /etc/chrony.conf
+  - /etc/sysconfig/chronyd
+  - /etc/ntp.conf
+  - /etc/sysconfig/ntpd
+  - /etc/ptp4l.conf
+  - /etc/sysconfig/ptp4l
+  - /etc/sysconfig/phc2sys
+  - /etc/timemaster.conf
+  - /etc/sysconfig/network
+__timesync_services:
+  - chronyd
+  - ntpd
+  - ntpdate
+  - phc2sys
+  - ptp4l
+  - sntp
+  - timemaster
+__timesync_services_suffix: "{{ __timesync_services | map('replace', '$', '.service') }}"
+__timesync_tar: /tmp/timesync_save.tar
+__timesync_services_json: /tmp/timesync_services.json
+__timesync_packages: [chrony, ntp, linuxptp]

--- a/tests/vars/main.yml
+++ b/tests/vars/main.yml
@@ -16,7 +16,8 @@ __timesync_services:
   - ptp4l
   - sntp
   - timemaster
-__timesync_services_suffix: "{{ __timesync_services | map('replace', '$', '.service') }}"
+__timesync_services_suffix: "{{ __timesync_services |
+  map('replace', '$', '.service') }}"
 __timesync_tar: /tmp/timesync_save.tar
 __timesync_services_json: /tmp/timesync_services.json
 __timesync_packages: [chrony, ntp, linuxptp]


### PR DESCRIPTION
This adds playbooks to run at certain points in tests:

tests/_before_test_suite.yml is intended to be run before the
first test (and before tests/_before_test.yml).  The intention
is to save any state (config files, services, packages) that need
to be restored after each test, or at the end of the test suite.

tests/_after_test.yml is intended to be run after each test - it
restores the state of the system to allow the next test to run

tests/_after_test_suite.yml - clean up anything left over - so
the next test suite can run cleanly

tests/_before_test.yml - not provided, but would be intended to
run before each test - not really useful for timesync

tests/vars/main.yml - vars shared by test playbooks

This will require support in CI to take advantage of this.  For
example, when creating a batch file like this:
```
... -- tests/_before_test_suite.yml tests/_before_test.yml tests/tests_1.yml tests/_after_test.yml
... -- tests/_before_test.yml tests/tests_2.yml tests/_after_test.yml
...
... -- tests/_before_test.yml tests/tests_N-1.yml tests/_after_test.yml
... -- tests/_before_test.yml tests/tests_N.yml tests/_after_test.yml tests/_after_test_suite.yml
```
