### PR TITLE
Update chrony.conf.j2 with type casting

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -21,9 +21,9 @@ value['hostname'] }}{{
 sourcedir {{ timesync_chrony_dhcp_sourcedir }}
 
 {% endif %}
-{% if timesync_step_threshold != 0.0 %}
+{% if timesync_step_threshold|float != 0.0 %}
 # Allow the system clock to be stepped in the first three updates.
-makestep {{ timesync_step_threshold if timesync_step_threshold > 0.0 else '1.0' }} 3
+makestep {{ timesync_step_threshold if timesync_step_threshold|float > 0.0 else '1.0' }} 3
 
 {% endif %}
 # Enable kernel synchronization of the real-time clock (RTC).
@@ -40,7 +40,7 @@ hwtimestamp {{ interface }}{% if __timesync_chrony_version is version('3.1', '>=
 {% endfor %}
 
 {% endif %}
-{% if timesync_min_sources > 1 %}
+{% if timesync_min_sources|int > 1 %}
 # Increase the minimum number of selectable sources required to adjust
 # the system clock.
 minsources {{ timesync_min_sources }}

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -21,9 +21,9 @@ value['hostname'] }}{{
 sourcedir {{ timesync_chrony_dhcp_sourcedir }}
 
 {% endif %}
-{% if timesync_step_threshold|float != 0.0 %}
+{% if timesync_step_threshold | float != 0.0 %}
 # Allow the system clock to be stepped in the first three updates.
-makestep {{ timesync_step_threshold if timesync_step_threshold|float > 0.0 else '1.0' }} 3
+makestep {{ timesync_step_threshold if timesync_step_threshold | float > 0.0 else '1.0' }} 3
 
 {% endif %}
 # Enable kernel synchronization of the real-time clock (RTC).
@@ -40,7 +40,7 @@ hwtimestamp {{ interface }}{% if __timesync_chrony_version is version('3.1', '>=
 {% endfor %}
 
 {% endif %}
-{% if timesync_min_sources|int > 1 %}
+{% if timesync_min_sources | int > 1 %}
 # Increase the minimum number of selectable sources required to adjust
 # the system clock.
 minsources {{ timesync_min_sources }}
@@ -74,7 +74,7 @@ generatecommandkey
 ntsdumpdir /var/lib/chrony
 
 {% endif %}
-{% if timesync_max_distance != 0 %}
+{% if timesync_max_distance | float != 0 %}
 # Limit maximum root distance.
 maxdistance {{ timesync_max_distance }}
 

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -74,7 +74,7 @@ generatecommandkey
 ntsdumpdir /var/lib/chrony
 
 {% endif %}
-{% if timesync_max_distance | float != 0 %}
+{% if timesync_max_distance | int != 0 %}
 # Limit maximum root distance.
 maxdistance {{ timesync_max_distance }}
 

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -40,7 +40,7 @@ tinker step {{ timesync_step_threshold }}
 tos minsane {{ timesync_min_sources }}
 
 {% endif %}
-{% if timesync_max_distance | float != 0 %}
+{% if timesync_max_distance | int != 0 %}
 # Limit maximum root distance.
 tos maxdist {{ timesync_max_distance }}
 

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -29,18 +29,18 @@ restrict -6 default nomodify notrap nopeer noquery
 restrict 127.0.0.1 
 restrict ::1
 
-{% if timesync_step_threshold >= 0.0 %}
+{% if timesync_step_threshold | float >= 0.0 %}
 # Specify the step threshold.
 tinker step {{ timesync_step_threshold }}
 
 {% endif %}
-{% if timesync_min_sources > 1 %}
+{% if timesync_min_sources | int > 1 %}
 # Increase the minimum number of selectable sources required to adjust
 # the system clock.
 tos minsane {{ timesync_min_sources }}
 
 {% endif %}
-{% if timesync_max_distance != 0 %}
+{% if timesync_max_distance | float != 0 %}
 # Limit maximum root distance.
 tos maxdist {{ timesync_max_distance }}
 

--- a/templates/phc2sys.sysconfig.j2
+++ b/templates/phc2sys.sysconfig.j2
@@ -1,3 +1,3 @@
 {{ ansible_managed | comment }}
 
-OPTIONS="-a -r{{ ' -F ' ~ timesync_step_threshold if timesync_step_threshold >= 0.0 else '' }}"
+OPTIONS="-a -r{{ ' -F ' ~ timesync_step_threshold if timesync_step_threshold | float >= 0.0 else '' }}"

--- a/templates/ptp4l.conf.j2
+++ b/templates/ptp4l.conf.j2
@@ -13,6 +13,6 @@ udp_ttl			{{ timesync_ptp_domains[0]['udp_ttl'] }}
 {% if 'hybrid_e2e' in timesync_ptp_domains[0] and timesync_ptp_domains[0]['hybrid_e2e'] %}
 hybrid_e2e		1
 {% endif %}
-{% if not timesync_mode2_hwts and timesync_step_threshold >= 0.0 %}
+{% if not timesync_mode2_hwts and timesync_step_threshold | float >= 0.0 %}
 first_step_threshold	{{ timesync_step_threshold }}
 {% endif %}


### PR DESCRIPTION
Variables are defined as string in Jinja2 template and the operators 
- on line 26 gives '<'  not supported between instances of 'str' and 'float
- on line 43 gives '>' not supported between instances of 'str' and 'float

changed template with type casting.
Had the problem on target RHEL 8.6  en RHEL9.0. In RHEL9.0 setting jinja2_native did work.

Tests done with:
ansible node has ansible 2.9.27/pyhton 3.8.10)
ansible node has ansible 2.9.27/pyhton 3.8.10)

Never had troubles with this system role and very unclear how the vars became strings in Jinja2 templating ..