### PR TITLE
Add check for non-inclusive language; 

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,19 @@
+---
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,7 +255,7 @@ must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
 
 - tag tests with slow
 - Remove python-26 environment from tox testing
-- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker
+- update to tox-lsr 2.4.0 - add support for ansible-test with docker
 
 [1.3.0] - 2021-02-11
 --------------------

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ timesync
 ![CI Testing](https://github.com/linux-system-roles/timesync/workflows/tox/badge.svg)
 
 This role installs and configures an NTP and/or PTP implementation to operate
+<!--- wokeignore:rule=slave -->
 as an NTP client and/or PTP slave in order to synchronize the system clock with
+<!--- wokeignore:rule=master -->
 NTP servers and/or grandmasters in PTP domains. Supported NTP/PTP
 implementations are chrony, ntp (the reference implementation) and linuxptp.
 
@@ -52,7 +54,7 @@ timesync_ptp_domains:
   - number: 0                   # PTP domain number
     interfaces: [eth0]          # List of interfaces in the domain
     delay: 0.000010             # Assumed maximum network delay to the
-                                # grandmaster in seconds
+                                # grandmaster in seconds # wokeignore:rule=master
                                 # (default 100 microsecond)
     transport: UDPv4            # Network transport: UDPv4, UDPv6, L2
                                 # (default UDPv4)
@@ -121,6 +123,7 @@ Install and configure ntp to synchronize the system clock with three NTP servers
 ```
 
 Install and configure linuxptp to synchronize the system clock with a
+<!--- wokeignore:rule=master -->
 grandmaster in PTP domain number 0, which is accessible on interface eth0:
 
 ```yaml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,7 +19,9 @@
     name: phc2sys
     state: restarted
 
+# wokeignore:rule=master
 - name: Restart timemaster
   service:
+    # wokeignore:rule=master
     name: timemaster
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,6 +103,7 @@
     dest: /etc/chrony.conf
     backup: true
     mode: 0644
+  # wokeignore:rule=master
   notify: Restart {{ 'chronyd' if timesync_mode == 1 else 'timemaster' }}
   when:
     - timesync_mode != 2
@@ -127,6 +128,7 @@
     dest: /etc/ntp.conf
     backup: true
     mode: 0644
+  # wokeignore:rule=master
   notify: Restart {{ 'ntpd' if timesync_mode == 1 else 'timemaster' }}
   when:
     - timesync_mode != 2
@@ -181,12 +183,16 @@
     - "'linuxptp' in ansible_facts.packages"
     - timesync_phc2sys_sysconfig_path | length > 0
 
+# wokeignore:rule=master
 - name: Generate timemaster.conf file
   template:
+    # wokeignore:rule=master
     src: timemaster.conf.j2
+    # wokeignore:rule=master
     dest: "{{ timesync_timemaster_config_path }}"
     backup: true
     mode: 0644
+  # wokeignore:rule=master
   notify: Restart timemaster
   when:
     - timesync_mode == 3
@@ -287,19 +293,23 @@
     - not __disable_result.msg is match(
       'Could not find the requested service phc2sys:')
 
+# wokeignore:rule=master
 - name: Disable timemaster
+  vars:
+    # wokeignore:rule=master
+    __timemstr: timemaster
   service:
-    name: timemaster
+    name: "{{ __timemstr }}"
     state: stopped
     enabled: false
   when:
     - timesync_mode != 3
-    - "'timemaster' in timesync_services"
+    - "'{{ __timemstr }}' in timesync_services"
   register: __disable_result
   failed_when:
     - __disable_result is failed
     - not __disable_result.msg is match(
-      'Could not find the requested service timemaster:')
+      'Could not find the requested service {{ __timemstr }}:')
 
 - name: Enable chronyd
   service:
@@ -335,8 +345,10 @@
     - timesync_mode == 2
     - timesync_mode2_hwts
 
+# wokeignore:rule=master
 - name: Enable timemaster
   service:
+    # wokeignore:rule=master
     name: timemaster
     state: started
     enabled: true

--- a/templates/ptp4l.conf.j2
+++ b/templates/ptp4l.conf.j2
@@ -1,6 +1,7 @@
 {{ ansible_managed | comment }}
 
 [global]
+{# wokeignore:rule=slave #}
 slaveOnly		1
 domainNumber		{{ timesync_ptp_domains[0].number }}
 time_stamping		{{ 'hardware' if timesync_mode2_hwts else 'software' }}

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -17,6 +17,7 @@ ptp4l_option hybrid_e2e 1
 {% endif %}
 
 {% endfor %}
+{# wokeignore:rule=master #}
 [timemaster]
 ntp_program {{ 'ntpd' if timesync_ntp_provider == 'ntp' else 'chronyd' }}
 

--- a/tests/tests_ptp_multi.yml
+++ b/tests/tests_ptp_multi.yml
@@ -55,8 +55,12 @@
                   - "'PTP1' in sources.stdout"
 
             - name: Run pmc
-              # yamllint disable-line rule:line-length
-              command: pmc -u -b 0 -d 0 -s /var/run/timemaster/ptp4l.0.socket 'GET DOMAIN' 'GET PORT_DATA_SET'
+              vars:
+                # wokeignore:rule=master
+                __sock: /var/run/timemaster/ptp4l.0.socket
+              command: >-
+                pmc -u -b 0 -d 0 -s "{{ __sock }}" 'GET DOMAIN'
+                'GET PORT_DATA_SET'
               register: pmc
               changed_when: false
 
@@ -74,8 +78,12 @@
                   ansible_distribution_version is not version('8.3', '<')
 
             - name: Run pmc
-              # yamllint disable-line rule:line-length
-              command: pmc -u -b 0 -d 1 -s /var/run/timemaster/ptp4l.1.socket 'GET DOMAIN' 'GET PORT_DATA_SET'
+              vars:
+                # wokeignore:rule=master
+                __sock: /var/run/timemaster/ptp4l.1.socket
+              command: >-
+                pmc -u -b 0 -d 1 -s "{{ __sock }}" 'GET DOMAIN'
+                'GET PORT_DATA_SET'
               register: pmc
               changed_when: false
 

--- a/vars/CentOS_6.yml
+++ b/vars/CentOS_6.yml
@@ -5,4 +5,5 @@ timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
 timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -5,4 +5,5 @@ timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
 timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,4 +5,5 @@ timesync_chrony_sysconfig_path: "/etc/default/chrony"
 timesync_ntp_sysconfig_path: "/etc/default/ntp"
 timesync_ptp4l_sysconfig_path: ""
 timesync_phc2sys_sysconfig_path: ""
+# wokeignore:rule=master
 timesync_timemaster_config_path: "/etc/linuxptp/timemaster.conf"

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -5,4 +5,5 @@ timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
 timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -5,4 +5,5 @@ timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
 timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -5,4 +5,5 @@ timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
 timesync_timemaster_config_path: /etc/timemaster.conf


### PR DESCRIPTION
Add check for non-inclusive language

Add a check for usage of terms and language that is considered non-inclusive. We are using the woke tool for this with a wordlist that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

Clean up / Workaround non-inclusive words
- CHANGELOG.md
- README.md
- handlers/main.yml
- tasks/main.yml
- templates/ptp4l.conf.j2
- templates/timemaster.conf.j2
- tests/tests_ptp_multi.yml
- vars/CentOS_6.yml
- vars/CentOS_9.yml
- vars/Debian.yml
- vars/RedHat_6.yml
- vars/RedHat_9.yml
- vars/default.yml

Note: woke action depends on https://github.com/linux-system-roles/tox-lsr/pull/103 for skipping the check on the filename timemaster.conf.j2.