### PR TITLE
Fix jinja formatting issue

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -304,12 +304,12 @@
     enabled: false
   when:
     - timesync_mode != 3
-    - "'{{ __timemstr }}' in timesync_services"
+    - __timemstr in timesync_services
   register: __disable_result
   failed_when:
     - __disable_result is failed
     - not __disable_result.msg is match(
-      'Could not find the requested service {{ __timemstr }}:')
+      'Could not find the requested service ' ~ __timemstr ~ ':')
 
 - name: Enable chronyd
   service:


### PR DESCRIPTION
Fix for the following warning:
```
TASK [linux-system-roles.timesync : Disable timemaster] ************************
[WARNING]: conditional statements should not include jinja2 templating
delimiters such as {{ }} or {% %}. Found: '{{ __timemstr }}' in
timesync_services
```
`when`, `that`, and similar are already interpreted as Jinja expressions
and do not require the use of {{ }}
