### PR TITLE
Fingerprint RHEL System Role managed config files

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 {% for value in timesync_ntp_servers %}
 {{ 'pool' if 'pool' in value and value['pool'] else 'server' }} {{

--- a/templates/chronyd.sysconfig.j2
+++ b/templates/chronyd.sysconfig.j2
@@ -1,3 +1,4 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 OPTIONS=""

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 {% for value in timesync_ntp_servers %}
 {{ 'pool' if 'pool' in value and value['pool'] else 'server' }} {{

--- a/templates/ntpd.sysconfig.j2
+++ b/templates/ntpd.sysconfig.j2
@@ -1,3 +1,4 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_distribution in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_distribution_major_version|int < 7 else '' }}"

--- a/templates/phc2sys.sysconfig.j2
+++ b/templates/phc2sys.sysconfig.j2
@@ -1,3 +1,4 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 OPTIONS="-a -r{{ ' -F ' ~ timesync_step_threshold if timesync_step_threshold | float >= 0.0 else '' }}"

--- a/templates/ptp4l.conf.j2
+++ b/templates/ptp4l.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 [global]
 {# wokeignore:rule=slave #}

--- a/templates/ptp4l.sysconfig.j2
+++ b/templates/ptp4l.sysconfig.j2
@@ -1,3 +1,4 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 OPTIONS="-f /etc/ptp4l.conf -i {{ timesync_ptp_domains[0].interfaces[0] }}"

--- a/templates/timemaster.conf.j2
+++ b/templates/timemaster.conf.j2
@@ -1,4 +1,5 @@
 {{ ansible_managed | comment }}
+{{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
 {% for value in timesync_ptp_domains %}
 [ptp_domain {{ value['number'] }}]


### PR DESCRIPTION
Add role name to the generated config files.
```
# system_role:timesync
```
Note: This information is provided to help customers identify that it was generated by System Roles. It may also be used for future analysis.