### PR TITLE
Update chrony.conf location for Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,7 +100,7 @@
 - name: Generate chrony.conf file
   template:
     src: chrony.conf.j2
-    dest: /etc/chrony.conf
+    dest: "{{ timesync_chrony_conf_path }}"
     backup: true
     mode: 0644
   # wokeignore:rule=master

--- a/vars/CentOS_6.yml
+++ b/vars/CentOS_6.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: ntp
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys

--- a/vars/CentOS_9.yml
+++ b/vars/CentOS_9.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: "chrony"
 timesync_chrony_dhcp_sourcedir: "/run/chrony-dhcp"
 timesync_chrony_sysconfig_path: "/etc/default/chrony"
+timesync_chrony_conf_path: "/etc/chrony/chrony.conf"
 timesync_ntp_sysconfig_path: "/etc/default/ntp"
 timesync_ptp4l_sysconfig_path: ""
 timesync_phc2sys_sysconfig_path: ""

--- a/vars/OracleLinux_6.yml
+++ b/vars/OracleLinux_6.yml
@@ -2,4 +2,5 @@
 timesync_ntp_provider_os_default: ntp
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd

--- a/vars/OracleLinux_7.yml
+++ b/vars/OracleLinux_7.yml
@@ -2,4 +2,5 @@
 timesync_ntp_provider_os_default: ntp
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd

--- a/vars/OracleLinux_8.yml
+++ b/vars/OracleLinux_8.yml
@@ -2,4 +2,5 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd

--- a/vars/OracleLinux_9.yml
+++ b/vars/OracleLinux_9.yml
@@ -2,4 +2,5 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: ntp
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys


### PR DESCRIPTION
The config file for chrony is in a different location on Debian (I missed that in #135 :-) )