### PR TITLE
test: check generated files for ansible_managed, fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 timesync
 ========
+
 ![CI Testing](https://github.com/linux-system-roles/timesync/workflows/tox/badge.svg)
 
 This role installs and configures an NTP and/or PTP implementation to operate
@@ -109,7 +110,8 @@ Example Playbook
 Install and configure ntp to synchronize the system clock with three NTP servers:
 
 ```yaml
-- hosts: targets
+- name: Manage timesync with 3 servers
+  hosts: targets
   vars:
     timesync_ntp_servers:
       - hostname: foo.example.com
@@ -127,7 +129,8 @@ Install and configure linuxptp to synchronize the system clock with a
 grandmaster in PTP domain number 0, which is accessible on interface eth0:
 
 ```yaml
-- hosts: targets
+- name: Manage timesync in PTP domain 0, interface eth0
+  hosts: targets
   vars:
     timesync_ptp_domains:
       - number: 0
@@ -141,7 +144,8 @@ multiple NTP servers and PTP domains for a highly accurate and resilient
 synchronization:
 
 ```yaml
-- hosts: targets
+- name: Manage multiple NTP servers and PTP domains
+  hosts: targets
   vars:
     timesync_ntp_servers:
       - hostname: foo.example.com
@@ -167,9 +171,9 @@ Install and configure chrony with multiple NTP servers and custom advanced
 settings: log `measurements`, `statistics` and `tracking`
 into `/var/log/chrony`:
 
-
 ```yaml
-- hosts: targets
+- name: Manage with custom advanced settings
+  hosts: targets
   vars:
     timesync_ntp_servers:
       - hostname: foo.example.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,16 +27,16 @@
 - name: Check if only NTP is needed
   set_fact:
     timesync_mode: 1
-  when: timesync_ptp_domains|length == 0
+  when: timesync_ptp_domains | length == 0
 
 - name: Check if single PTP is needed
   set_fact:
     timesync_mode: 2
   when:
     - timesync_mode is not defined
-    - timesync_ntp_servers|length == 0
-    - timesync_ptp_domains|length == 1
-    - timesync_ptp_domains[0].interfaces|length == 1
+    - timesync_ntp_servers | length == 0
+    - timesync_ptp_domains | length == 1
+    - timesync_ptp_domains[0].interfaces | length == 1
 
 - name: Check if both NTP and PTP are needed
   set_fact:

--- a/templates/ntpd.sysconfig.j2
+++ b/templates/ntpd.sysconfig.j2
@@ -1,4 +1,4 @@
 {{ ansible_managed | comment }}
 {{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
-OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_distribution in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_distribution_major_version|int < 7 else '' }}"
+OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_distribution in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_distribution_major_version | int < 7 else '' }}"

--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get file
+  slurp:
+    path: "{{ __file }}"
+  register: __content
+  when: not __file_content is defined
+
+- name: Check for presence of ansible managed header, fingerprint
+  assert:
+    that:
+      - ansible_managed in content
+      - __fingerprint in content
+  vars:
+    content: "{{ (__file_content | d(__content)).content | b64decode }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment(__comment_type | d("plain")) }}

--- a/tests/tests_chrony.yml
+++ b/tests/tests_chrony.yml
@@ -19,10 +19,13 @@
     timesync_step_threshold: 0.01
     timesync_dhcp_ntp_servers: true
     timesync_min_sources: 2
-  roles:
-    - linux-system-roles.timesync
 
   tasks:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.timesync
+        public: true
+
     - name: Run chrony tests
       tags: tests::verify
       block:
@@ -54,3 +57,13 @@
           assert:
             that:
               - "'tracking.log' in logfiles.stdout"
+
+        - name: Check headers for ansible_managed, fingerprint
+          include_tasks: tasks/check_header.yml
+          loop:
+            - "{{ timesync_chrony_conf_path }}"
+            - "{{ timesync_chrony_sysconfig_path }}"
+          loop_control:
+            loop_var: __file
+          vars:
+            __fingerprint: "system_role:timesync"

--- a/tests/tests_ntp.yml
+++ b/tests/tests_ntp.yml
@@ -22,10 +22,12 @@
     timesync_dhcp_ntp_servers: true
     timesync_min_sources: 2
     timesync_ntp_hwts_interfaces: ["*"]
-  roles:
-    - linux-system-roles.timesync
-
   tasks:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.timesync
+        public: true
+
     - name: Run test
       tags: tests::verify
       block:
@@ -108,4 +110,32 @@
               - ntp_conf is not search('172\.16\.123\.1.*true')
               - ntp_conf is not search('172\.16\.123\.2.*true')
               - ntp_conf is search('172\.16\.123\.3.*true')
+          when: ntp_conf is defined
+
+        - name: Check chrony conf for ansible_managed, fingerprint
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file_content: "{{ chrony_conf_encoded }}"
+            __fingerprint: "system_role:timesync"
+          when: chrony_conf is defined
+
+        - name: Check chrony sysconf for ansible_managed, fingerprint
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file: "{{ timesync_chrony_sysconfig_path }}"
+            __fingerprint: "system_role:timesync"
+          when: chrony_conf is defined
+
+        - name: Check ntp conf for ansible_managed, fingerprint
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file_content: "{{ ntp_conf_encoded }}"
+            __fingerprint: "system_role:timesync"
+          when: ntp_conf is defined
+
+        - name: Check ntp sysconf for ansible_managed, fingerprint
+          include_tasks: tasks/check_header.yml
+          vars:
+            __file: "{{ timesync_ntp_sysconfig_path }}"
+            __fingerprint: "system_role:timesync"
           when: ntp_conf is defined


### PR DESCRIPTION
Clean up more ansible-lint issues in code and README

Add the following files: tests/tasks/check_header.yml and
tests/templates/get_ansible_managed.j2.
Use check_header.yml to check generated files for the ansible_managed
and fingerprint headers.
check_header.yml takes these parameters.  `fingerprint` is required,
and one of `__file` or `__file_content`:

* `__file` - the full path of the file to check e.g. `/etc/realmd.conf`
* `__file_content` - the output of `slurp` of the file
* `__fingerprint` - required - the fingerprint string `system_role:$ROLENAME` e.g.
  `__fingerprint: "system_role:postfix"`
* `__comment_type` - optional, default `plain` - the type of comments used

e.g. `__comment_type: c` for C/C++-style comments.  `plain` uses `#`.
See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files
for the different types of comment styles supported.

Example:
```
- name: Check generated files for ansible_managed, fingerprint
  include_tasks: tasks/check_header.yml
  vars:
    __file: /etc/myfile.conf
    __fingerprint: "system_role:my_role"
```

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
