### PR TITLE
refactor: Add CentOS 7-8, RedHat 7-8 and AlmaLinux 8-9 var files

### DIFF
--- a/vars/AlmaLinux_8.yml
+++ b/vars/AlmaLinux_8.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: ""
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/AlmaLinux_9.yml
+++ b/vars/AlmaLinux_9.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: ""
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: ""
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: ""
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf


### PR DESCRIPTION
Enhancement: Add variables for additional operating systems.

Reason: They are missing, so values in `default.yml` are used.

Result: Everything works as expected in the added operating systems.

The default values are fine for all the operating systems listed, so in my opinion the best approach would be to get rid of all of them, leaving only `default.yml` and simplify. But in the meanwhile, this makes these additional OSes "compliant".