### PR TITLE
Add allow directive in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ timesync_ntp_hwts_interfaces: ["*"]
 # package specific to the system and its version will be selected.
 timesync_ntp_provider: chrony
 
+# List of allowed network, ips and ranges that can request time.
+# This is required to operate chrony as a server, without it chronyd operates
+# purely as an NTP client.
+timesync_allow:
+  - 1.2.3.4
+  - 3.4.5.0/24
+  - all
+
 # Sometimes administrators might need extended configurations for chrony which
 # are not covered by the predefined settings provided by this role.
 # 'timesync_chrony_custom_settings' allows to define a list of custom settings

--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -17,6 +17,13 @@ value['hostname'] }}{{
                 'filter' in value and value['filter'] > 1 else '' }}
 {% endfor %}
 
+{% if timesync_allow is defined %}
+# Allowed networks to contact chronyd when not running only as a client.
+{% for address in timesync_allow %}
+allow {{ address }}
+{% endfor %}
+{% endif %}
+
 {% if timesync_dhcp_ntp_servers and timesync_chrony_dhcp_sourcedir %}
 # Use NTP servers from DHCP.
 sourcedir {{ timesync_chrony_dhcp_sourcedir }}


### PR DESCRIPTION
Enhancement: Add `allow` directive in `chrony.conf` configuration file and relevant documentation.

Reason: This directive is required to configure `chrony` in server mode, otherwise it operates purely as an NTP client.

Result: `chrony` starts in server mode and listens to port 123 as described in the `chrony.conf(5)` `man` page.