### PR TITLE
ci: Add ALP-Dolomite var file

### DIFF
--- a/vars/ALP-Dolomite.yml
+++ b/vars/ALP-Dolomite.yml
@@ -1,0 +1,8 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntp
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys


### PR DESCRIPTION
Enhancement: Add variables for additional operating system.

Reason: The existing configuration does not cover [SUSE ALP](https://documentation.suse.com/alp/dolomite/html/alp-dolomite/index.html), the default configurations are being used.

Result: Works as expected in the added operating system.

Issue Tracker Tickets (Jira or BZ if any):na
