### PR TITLE
ci: fix python unit test - copy pytest config to tests/unit

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -17,7 +17,7 @@ kinds:
 skip_list:
   - fqcn-builtins
   - var-naming[no-role-prefix]
-  - sanity[cannot-ignore]
+  - sanity[cannot-ignore]  # wokeignore:rule=sanity
 exclude_paths:
   - tests/roles/
   - .github/

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.1"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.2.2"
 
       - name: Convert role to collection format
         run: |


### PR DESCRIPTION
This is fixed by tox-lsr 3.2.2 - all actions that use tox-lsr are updated to
3.2.2, not just the python unit tests, even though the fix is only related to
pytest.  All roles are updated to use tox-lsr 3.2.2 for the sake of consistency
even if not affected by the pytest issue.

Something changed recently in the way github actions provisions systems which
means some of the directories are not readable by the python unit test actions.
In addition, the python unit tests were causing a lot of unnecessary directory
traversal doing collection/discovery of unit test files, because of using
`pytest -c /path/to/tox-lsr/pytest.ini` Unfortunately, with `pytest`, the
directory of the config file is the root directory for the tests and tests
discovery, and there is no way around this.

Therefore, the only solution is to copy the tox-lsr `pytest.ini` to the
`tests/unit` directory, which makes that the test root directory.

See also https://github.com/linux-system-roles/tox-lsr/pull/160

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
