### PR TITLE
feat: Implements CIS Benchmark - 2.1.2 Ensure chrony is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+[1.8.3] - 2024-04-04
+--------------------
+
+### Other Changes
+
+- ci: fix python unit test - copy pytest config to tests/unit (#234)
+- ci: Bump ansible/ansible-lint from 6 to 24 (#235)
+- ci: Bump mathieudutour/github-tag-action from 6.1 to 6.2 (#237)
+
 [1.8.2] - 2024-01-16
 --------------------
 
@@ -76,7 +85,6 @@ Changelog
   
   Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
 
-
 [1.7.7] - 2023-09-11
 --------------------
 
@@ -109,7 +117,6 @@ Changelog
   - Remove badges from README.md prior to converting to HTML
   
   Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
-
 
 [1.7.6] - 2023-07-19
 --------------------
@@ -210,7 +217,6 @@ on line 43 gives '>' not supported between instances of 'str' and 'float
 - Updated: type casting in overall timesync templates for testing
 
 - Updated: type casting adjusted (timesync_max_distance <= int)
-
 
 ### Other Changes
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ timesync_ntp_provider: chrony
 timesync_chrony_custom_settings:
   - "logdir /var/log/chrony"
   - "log measurements statistics tracking"
+
+# List of daeomn options that will be configured at startup of the services
+# using 'OPTIONS' variable in '/etc/sysconfig/chronyd'. For all available
+# options, see 'chronyd(8)' man page.
+timesync_chrony_service_settings: []
 ```
 
 ## Example Playbooks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ timesync_min_sources: 1
 timesync_ntp_hwts_interfaces: []
 timesync_ntp_provider: ""
 timesync_max_distance: 0
+timesync_chrony_service_settings: []

--- a/templates/chronyd.sysconfig.j2
+++ b/templates/chronyd.sysconfig.j2
@@ -1,4 +1,4 @@
 {{ ansible_managed | comment }}
 {{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
-OPTIONS=""
+OPTIONS="{{ timesync_chrony_service_settings | default([]) | join(' ') }}"


### PR DESCRIPTION
Enhancement:
I changed the template for chrony sysconfig in order to implement CIS Benchmark recomendation for RHEL.

Reason:
Be compatible with CIS Benchmark "2.1.2 Ensure chrony is configured" on a RHEL.

Result:
CIS Benchmark compatible.

Issue Tracker Tickets (Jira or BZ if any):
N.A.