### PR TITLE
fix: add support for EL10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,17 +2,6 @@
 galaxy_info:
   author: Miroslav Lichvar <mlichvar@redhat.com>
   description: Configure NTP and/or PTP
-  galaxy_tags:
-    - system
-    - time
-    - redhat
-    - rhel
-    - fedora
-    - centos
-    - ntp
-    - ntpd
-    - chrony
-    - ptp
   company: Red Hat, Inc.
   license: MIT
   min_ansible_version: "2.9"
@@ -26,3 +15,19 @@ galaxy_info:
         - "7"
         - "8"
         - "9"
+  galaxy_tags:
+    - centos
+    - chrony
+    - el6
+    - el7
+    - el8
+    - el9
+    - el10
+    - fedora
+    - ntp
+    - ntpd
+    - ptp
+    - redhat
+    - rhel
+    - system
+    - time

--- a/vars/AlmaLinux_10.yml
+++ b/vars/AlmaLinux_10.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf

--- a/vars/OracleLinux_10.yml
+++ b/vars/OracleLinux_10.yml
@@ -1,0 +1,6 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,0 +1,10 @@
+---
+timesync_ntp_provider_os_default: chrony
+timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_conf_path: "/etc/chrony.conf"
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
+timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
