### PR TITLE
fix: Don't use chrony-dhcp sourcedir on EL8 systems

### DIFF
--- a/vars/OracleLinux_8.yml
+++ b/vars/OracleLinux_8.yml
@@ -1,6 +1,6 @@
 ---
 timesync_ntp_provider_os_default: chrony
-timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -1,6 +1,6 @@
 ---
 timesync_ntp_provider_os_default: chrony
-timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
+timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd


### PR DESCRIPTION
On EL8 systems the chrony package uses a helper script which adds servers from DHCP with the "chronyc add" command. The /run/chrony-dhcp directive is used on EL9 and later.
