### PR TITLE
docs: add module documentation for timesync_provider

### DIFF
--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -1,1 +1,2 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.11.txt
+++ b/.sanity-ansible-ignore-2.11.txt
@@ -1,1 +1,2 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,1 +1,2 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,1 +1,2 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,3 +1,4 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license
 plugins/modules/timesync_provider.sh validate-modules:invalid-extension
 plugins/modules/timesync_provider.sh validate-modules:python-syntax-error

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,3 +1,4 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license
 plugins/modules/timesync_provider.sh validate-modules:invalid-extension
 plugins/modules/timesync_provider.sh validate-modules:python-syntax-error

--- a/.sanity-ansible-ignore-2.16.txt
+++ b/.sanity-ansible-ignore-2.16.txt
@@ -1,3 +1,4 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license
 plugins/modules/timesync_provider.sh validate-modules:invalid-extension
 plugins/modules/timesync_provider.sh validate-modules:python-syntax-error

--- a/.sanity-ansible-ignore-2.17.txt
+++ b/.sanity-ansible-ignore-2.17.txt
@@ -1,3 +1,4 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license
 plugins/modules/timesync_provider.sh validate-modules:invalid-extension
 plugins/modules/timesync_provider.sh validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,1 +1,2 @@
 plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license

--- a/library/timesync_provider.yml
+++ b/library/timesync_provider.yml
@@ -1,0 +1,19 @@
+DOCUMENTATION:
+  module: timesync_provider
+  short_description: Determine the timesync provider on the system
+  version_added: "2.14.0"
+  description:
+    - "WARNING: Do not use this module directly! It is only for role internal use."
+    - "Determine the timesync provider on the system and return it."
+  options: {}
+  author:
+    - Miroslav Lichvar (@mlichvar)
+EXAMPLES: |-
+  - name: Determine current NTP provider
+    timesync_provider:
+RETURN:
+  timesync_ntp_provider_current:
+    description: Name of current provider e.g. chrony or ntp
+    returned: success
+    type: str
+    sample: chrony


### PR DESCRIPTION
Automation Hub will error and not display module docs for
any module if any of the docs are missing or incorrect.
Since timesync_provider is a shell script, it must have
a separate module doc file.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
