### PR TITLE
ci: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ timesync_chrony_custom_settings:
   - "logdir /var/log/chrony"
   - "log measurements statistics tracking"
 
-#This variable is used to handle reboots required by transactional updates.
-#If a transactional update requires a reboot, the role will proceed with the
-#reboot if `timesync_transactional_update_reboot_ok` is set to `true`. If set
-#to `false`, the role will notify the user that a reboot is required, allowing
-#for custom handling of the reboot requirement. If this variable is not set,
-#the role will fail to ensure the reboot requirement is not overlooked.
+# This variable is applicable only for transactional update systems.
+# If a transactional update requires a reboot, the role will proceed with the
+# reboot if `timesync_transactional_update_reboot_ok` is set to `true`. If set
+# to `false`, the role will notify the user that a reboot is required, allowing
+# for custom handling of the reboot requirement. If this variable is not set,
+# the role will fail to ensure the reboot requirement is not overlooked.
+# For non-transactional update systems, this variable is ignored.
 timesync_transactional_update_reboot_ok: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ timesync_ntp_provider: chrony
 timesync_chrony_custom_settings:
   - "logdir /var/log/chrony"
   - "log measurements statistics tracking"
+
+#This variable is used to handle reboots required by transactional updates.
+#If a transactional update requires a reboot, the role will proceed with the
+#reboot if `timesync_transactional_update_reboot_ok` is set to `true`. If set
+#to `false`, the role will notify the user that a reboot is required, allowing
+#for custom handling of the reboot requirement. If this variable is not set,
+#the role will fail to ensure the reboot requirement is not overlooked.
+timesync_transactional_update_reboot_ok: true
 ```
 
 ## Example Playbooks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ timesync_min_sources: 1
 timesync_ntp_hwts_interfaces: []
 timesync_ntp_provider: ""
 timesync_max_distance: 0
+timesync_transactional_update_reboot_ok: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,7 @@
   when:
     - timesync_mode != 2
     - timesync_ntp_provider == 'chrony'
+  register: timesync_chrony_result
 
 - name: Install ntp
   package:
@@ -77,6 +78,7 @@
   when:
     - timesync_mode != 2
     - timesync_ntp_provider == 'ntp'
+  register: timesync_ntp_result
 
 - name: Install linuxptp
   package:
@@ -85,6 +87,32 @@
     use: "{{ (__timesync_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: timesync_mode != 1
+  register: timesync_linuxptp_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __timesync_is_transactional | d(false)
+    - timesync_chrony_result is changed or
+      timesync_ntp_result is changed or
+      timesync_linuxptp_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: timesync_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set
+          'timesync_transactional_update_reboot_ok' to proceed.
+      when:
+        - timesync_transactional_update_reboot_ok is none
 
 - name: Gather package facts
   package_facts:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -17,6 +17,18 @@
       set_fact:
         __timesync_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __timesync_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __timesync_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Set platform/version specific variables
   include_vars: "{{ lookup('first_found', ffparams) }}"
   vars:

--- a/vars/SL-Micro.yml
+++ b/vars/SL-Micro.yml
@@ -3,6 +3,8 @@ timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
 timesync_chrony_conf_path: "/etc/chrony.conf"
-timesync_ntp_sysconfig_path: /etc/sysconfig/ntp
+timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l
 timesync_phc2sys_sysconfig_path: /etc/sysconfig/phc2sys
+# wokeignore:rule=master
+timesync_timemaster_config_path: /etc/timemaster.conf


### PR DESCRIPTION
Enhancement: - Added a block to identify and handle reboots for transactional update systems on package changes. Update README. Rename ALP-Dolomite var file to SL-Micro as the name is no longer used.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
