### PR TITLE
ci: Create inventory for wrapper test with inventory_hostname

### DIFF
--- a/tests/inventory.yaml.j2
+++ b/tests/inventory.yaml.j2
@@ -1,1 +1,11 @@
-{{ { 'all': { 'hosts': hostvars } } | to_yaml }}
+all:
+  hosts:
+    {{ inventory_hostname }}:
+{% for key in ["ansible_all_ipv4_addresses", "ansible_all_ipv6_addresses",
+                 "ansible_default_ipv4", "ansible_default_ipv6", "ansible_host",
+                 "ansible_port", "ansible_ssh_common_args",
+                 "ansible_ssh_private_key_file","ansible_user"] %}
+{%   if key in hostvars[inventory_hostname] %}
+      {{ key }}: {{ hostvars[inventory_hostname][key] }}
+{%   endif %}
+{% endfor %}


### PR DESCRIPTION
Enhancement: Create inventory for wrapper test with inventory_hostname

Reason: Multihost tests have an inventory defining many nodes, then run playbooks with `--limit <node>`. Hence, the role must build inventory for wrapper tests only with the node that it runs against.

Result: Inventory that is created for wrapper tests contains a single node like in https://github.com/linux-system-roles/kdump/blob/main/tests/inventory.yaml.j2
