### PR TITLE
feat: add support for timesync_ntp_ip_family

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ timesync_chrony_custom_settings:
 # the role will fail to ensure the reboot requirement is not overlooked.
 # For non-transactional update systems, this variable is ignored.
 timesync_transactional_update_reboot_ok: true
+
+# This option is useful on systems where IPv6 or IPv4 are disabled.
+# chronyd will work on a IPv6-disabled host without -4, but it logs error messages
+# when binding to the IPv6 sockets fails. Adding the -4 option disables those sockets
+# and there are no error messages. It's also useful to prevent the client from using
+# IPv6 servers when IPv4 is known to work better (e.g. IPv6 over a tunnel).
+# Corresponds to the `-4` and `-6` OPTIONS for chronyd and ntpd.  Values are:
+# * IPv4 - use only IPv4
+# * IPv6 - use only IPv6
+# * all - use both IPv4 and IPv6
+# Default is all
+timesync_ntp_ip_family: all
 ```
 
 ## Example Playbooks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,6 @@ timesync_ntp_hwts_interfaces: []
 timesync_ntp_provider: ""
 timesync_max_distance: 0
 timesync_transactional_update_reboot_ok: null
+# options are all, IPv4, IPv6
+# default is none which is platform default
+timesync_ntp_ip_family: ""

--- a/templates/chronyd.sysconfig.j2
+++ b/templates/chronyd.sysconfig.j2
@@ -1,4 +1,6 @@
 {{ ansible_managed | comment }}
 {{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
-OPTIONS=""
+OPTIONS="{{ ' -4' if timesync_ntp_ip_family == 'IPv4'
+    else ' -6' if timesync_ntp_ip_family == 'IPv6'
+    else '' }}"

--- a/templates/ntpd.sysconfig.j2
+++ b/templates/ntpd.sysconfig.j2
@@ -1,4 +1,7 @@
 {{ ansible_managed | comment }}
 {{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
-OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_distribution in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_distribution_major_version | int < 7 else '' }}"
+OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_distribution in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_distribution_major_version | int < 7 else '' }}{{
+    ' -4' if timesync_ntp_ip_family == 'IPv4'
+    else ' -6' if timesync_ntp_ip_family == 'IPv6'
+    else '' }}"

--- a/tests/tests_default_vars.yml
+++ b/tests/tests_default_vars.yml
@@ -19,3 +19,4 @@
         - timesync_ntp_hwts_interfaces
         - timesync_ntp_provider
         - timesync_max_distance
+        - timesync_ntp_ip_family

--- a/tests/tests_options.yml
+++ b/tests/tests_options.yml
@@ -1,0 +1,55 @@
+---
+- name: Test setting OPTIONS
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Run tests
+      block:
+        - name: Run role with no arguments to get provider
+          include_role:
+            name: linux-system-roles.timesync
+            public: true
+
+        - name: Set vars based on provider
+          set_fact:
+            __test_file: "{{ timesync_chrony_sysconfig_path
+              if timesync_ntp_provider_current == 'chrony'
+              else timesync_ntp_sysconfig_path }}"
+
+        - name: Try timesync_ntp_ip_family IPv4
+          include_role:
+            name: linux-system-roles.timesync
+          vars:
+            timesync_ntp_ip_family: IPv4
+
+        - name: Verify IPv4 setting
+          command: grep 'OPTIONS=.* -4' {{ __test_file }}
+          changed_when: false
+
+        - name: Try timesync_ntp_ip_family IPv6
+          include_role:
+            name: linux-system-roles.timesync
+          vars:
+            timesync_ntp_ip_family: IPv6
+
+        - name: Verify IPv6 setting
+          command: grep 'OPTIONS=.* -6' {{ __test_file }}
+          changed_when: false
+
+      always:
+        - name: Reset OPTIONS
+          include_role:
+            name: linux-system-roles.timesync
+          vars:
+            timesync_ntp_ip_family: all
+
+        - name: Verify reset
+          shell: |
+            set -eux
+            if grep 'OPTIONS=.* -4' {{ __test_file }} || \
+              grep 'OPTIONS=.* -6' {{ __test_file }}; then
+                echo ERROR: {{ __test_file }} has incorrect OPTIONS
+                exit 1
+            fi
+            exit 0
+          changed_when: false


### PR DESCRIPTION
Feature: Add support for timesync_ntp_ip_family to allow setting the `-4`
or `-6` OPTIONS in the chronyd or ntpd sysconfig file.

Reason: When IPv6 is disabled on the node, you must tell chronyd to
only listen for IPv4 using OPTIONS="-4" in the sysconfig file.
Otherwise, chronyd will log error messages when binding to IPv6 sockets
It's also useful to prevent the client from using IPv6 servers when IPv4
is known to work better (e.g. IPv6 over a tunnel).

Result: chronyd and ntpd can be configured to work correctly, and
the services will not log errors, when IPv6 (or IPv4) is disabled
on the node.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
