### PR TITLE
fix: add default seccomp filters for el9/10

### DIFF
--- a/templates/chronyd.sysconfig.j2
+++ b/templates/chronyd.sysconfig.j2
@@ -1,6 +1,5 @@
 {{ ansible_managed | comment }}
 {{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
-OPTIONS="{{ ' -4' if timesync_ntp_ip_family == 'IPv4'
-    else ' -6' if timesync_ntp_ip_family == 'IPv6'
-    else '' }}"
+OPTIONS="{{ timesync_chrony_sysconfig_options }}{{ ' -4' if timesync_ntp_ip_family == 'IPv4'
+    else ' -6' if timesync_ntp_ip_family == 'IPv6' else '' }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: "chrony"
 timesync_chrony_dhcp_sourcedir: "/run/chrony-dhcp"
 timesync_chrony_sysconfig_path: "/etc/default/chrony"
+timesync_chrony_sysconfig_options: ""
 timesync_chrony_conf_path: "/etc/chrony/chrony.conf"
 timesync_ntp_sysconfig_path: "/etc/default/ntp"
 timesync_ptp4l_sysconfig_path: ""

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: "-F 2"
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l

--- a/vars/RedHat_6.yml
+++ b/vars/RedHat_6.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: ntp
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: ""
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: ""
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l

--- a/vars/RedHat_8.yml
+++ b/vars/RedHat_8.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: ""
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l

--- a/vars/RedHat_9.yml
+++ b/vars/RedHat_9.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: "-F 2"
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l

--- a/vars/SL-Micro.yml
+++ b/vars/SL-Micro.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: ""
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -2,6 +2,7 @@
 timesync_ntp_provider_os_default: chrony
 timesync_chrony_dhcp_sourcedir: ""
 timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
+timesync_chrony_sysconfig_options: ""
 timesync_chrony_conf_path: "/etc/chrony.conf"
 timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
 timesync_ptp4l_sysconfig_path: /etc/sysconfig/ptp4l


### PR DESCRIPTION
Cause: The timesync role is replacing the default `OPTIONS=` setting for chronyd with `""` upon every role run.

Consequence: This removes the default `OPTIONS="-F 2"` setting on EL9 and EL10 which weakens the security of chronyd.

Fix: Add `-F 2` as the default setting for `OPTIONS` in EL9 and EL10.  Ensure that the user can override this setting if necessary, and ensure that this setting can co-exist with other `OPTIONS` settings that may be set by the user.

Result: The timesync role applies the correct security settings on every platform and allows the user to override/extend these settings.

Fixes #278 