### PR TITLE
refactor: make OracleLinux vars files symlinks to RedHat vars files

### DIFF
--- a/vars/OracleLinux_10.yml
+++ b/vars/OracleLinux_10.yml
@@ -1,6 +1,1 @@
----
-timesync_ntp_provider_os_default: chrony
-timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
-timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
-timesync_chrony_conf_path: "/etc/chrony.conf"
-timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+RedHat_10.yml

--- a/vars/OracleLinux_6.yml
+++ b/vars/OracleLinux_6.yml
@@ -1,6 +1,1 @@
----
-timesync_ntp_provider_os_default: ntp
-timesync_chrony_dhcp_sourcedir: ""
-timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
-timesync_chrony_conf_path: "/etc/chrony.conf"
-timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+RedHat_6.yml

--- a/vars/OracleLinux_7.yml
+++ b/vars/OracleLinux_7.yml
@@ -1,6 +1,1 @@
----
-timesync_ntp_provider_os_default: ntp
-timesync_chrony_dhcp_sourcedir: ""
-timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
-timesync_chrony_conf_path: "/etc/chrony.conf"
-timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+RedHat_7.yml

--- a/vars/OracleLinux_8.yml
+++ b/vars/OracleLinux_8.yml
@@ -1,6 +1,1 @@
----
-timesync_ntp_provider_os_default: chrony
-timesync_chrony_dhcp_sourcedir: ""
-timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
-timesync_chrony_conf_path: "/etc/chrony.conf"
-timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+RedHat_8.yml

--- a/vars/OracleLinux_9.yml
+++ b/vars/OracleLinux_9.yml
@@ -1,6 +1,1 @@
----
-timesync_ntp_provider_os_default: chrony
-timesync_chrony_dhcp_sourcedir: /run/chrony-dhcp
-timesync_chrony_sysconfig_path: /etc/sysconfig/chronyd
-timesync_chrony_conf_path: "/etc/chrony.conf"
-timesync_ntp_sysconfig_path: /etc/sysconfig/ntpd
+RedHat_9.yml


### PR DESCRIPTION
The OracleLinux vars files were out of sync with the other EL vars.
There is no reason for this, they should be exactly the same.
Make the OracleLinux vars files symlinks to the RedHat vars files,
like the other EL vars files.

Fixes https://github.com/linux-system-roles/timesync/issues/282
