### PR TITLE
test: ensure tests cleanup and restore the system state

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -1,0 +1,6 @@
+---
+- name: Reset provider to os default
+  include_role:
+    name: linux-system-roles.timesync
+  vars:
+    timesync_ntp_provider: "{{ timesync_ntp_provider_os_default }}"

--- a/tests/tests_chrony.yml
+++ b/tests/tests_chrony.yml
@@ -67,3 +67,7 @@
             loop_var: __file
           vars:
             __fingerprint: "system_role:timesync"
+
+      always:
+        - name: Cleanup after tests
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_ntp_provider4.yml
+++ b/tests/tests_ntp_provider4.yml
@@ -5,10 +5,7 @@
     timesync_ntp_servers:
       - hostname: 172.16.123.1
     timesync_ntp_provider: chrony
-  roles:
-    - linux-system-roles.timesync
-
-  pre_tasks:
+  tasks:
     - name: Common test setup tasks
       include_tasks: tasks/setup.yml
       vars:
@@ -27,21 +24,31 @@
 
         - name: Skip test if no package
           meta: end_play
-          when: package_install.failed
+          when: package_install is failed
 
         - name: Remove chrony
           package:
             name: chrony
             state: absent
 
-  post_tasks:
-    - name: Verify chronyd is running
-      tags: tests::verify
+    - name: Run the test
       block:
-        - name: Wait for services to start
-          wait_for:
-            timeout: 2
+        - name: Run the role
+          include_role:
+            name: linux-system-roles.timesync
+            public: true
 
-        - name: Check chronyd service
-          command: chronyc -n tracking
-          changed_when: false
+        - name: Verify chronyd is running
+          tags: tests::verify
+          block:
+            - name: Wait for services to start
+              wait_for:
+                timeout: 2
+
+            - name: Check chronyd service
+              command: chronyc -n tracking
+              changed_when: false
+
+      always:
+        - name: Cleanup after tests
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_ntp_provider5.yml
+++ b/tests/tests_ntp_provider5.yml
@@ -5,10 +5,7 @@
     timesync_ntp_servers:
       - hostname: 172.16.123.1
     timesync_ntp_provider: ntp
-  roles:
-    - linux-system-roles.timesync
-
-  pre_tasks:
+  tasks:
     - name: Common test setup tasks
       include_tasks: tasks/setup.yml
       vars:
@@ -34,19 +31,29 @@
             name: ntp
             state: absent
 
-  post_tasks:
-    - name: Verify ntpd service
-      tags: tests::verify
+    - name: Run test
       block:
-        - name: Wait for services to start
-          wait_for:
-            timeout: 2
+        - name: Run the role
+          include_role:
+            name: linux-system-roles.timesync
+            public: true
 
-        - name: Check ntpd service
-          shell: |
-            set -eu
-            if set -o | grep -q pipefail; then
-              set -o pipefail  # no pipefail on debian, some ubuntu
-            fi
-            ntpq -c rv | grep 'associd=0'
-          changed_when: false
+        - name: Verify ntpd service
+          tags: tests::verify
+          block:
+            - name: Wait for services to start
+              wait_for:
+                timeout: 2
+
+            - name: Check ntpd service
+              shell: |
+                set -eu
+                if set -o | grep -q pipefail; then
+                  set -o pipefail  # no pipefail on debian, some ubuntu
+                fi
+                ntpq -c rv | grep 'associd=0'
+              changed_when: false
+
+      always:
+        - name: Cleanup after tests
+          include_tasks: tasks/cleanup.yml

--- a/tests/tests_ntp_provider6.yml
+++ b/tests/tests_ntp_provider6.yml
@@ -54,6 +54,7 @@
     - name: Call role to change provider
       include_role:
         name: linux-system-roles.timesync
+        public: true
       vars:
         # ntp is the default choice for RedHat and CentOS
         # version < 7.0 - reverse it

--- a/tests/tests_ntp_ptp.yml
+++ b/tests/tests_ntp_ptp.yml
@@ -30,6 +30,7 @@
         - name: Run role
           include_role:
             name: linux-system-roles.timesync
+            public: true
 
         - name: Flush handlers
           meta: flush_handlers
@@ -66,3 +67,10 @@
                   - "'172.16.123.2' in sources.stdout"
                   - "'PTP0' in sources.stdout"
                   - "'PTP1' in sources.stdout"
+
+      always:
+        - name: Cleanup after tests
+          include_tasks: tasks/cleanup.yml
+          vars:
+            timesync_ntp_servers: []
+            timesync_ptp_domains: []


### PR DESCRIPTION
Ensure the tests cleanup and restore the system state.
Refactor tests to use a `block/always` so that cleanup can
occur in the `always` block.
Add a tests/tasks/cleanup.yml tasks file which is run from
the `always` block of the test, and include this task file
to be run from the `always` block of tests that require cleanup.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
