### PR TITLE
refactor: support ansible 2.19; fix ansible-lint issues

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tests_ntp_provider6.yml
+++ b/tests/tests_ntp_provider6.yml
@@ -91,7 +91,7 @@
       vars:
         timesync_ntp_provider: "{{ timesync_ntp_provider_os_default }}"
 
-    - name: Verify provider set correctly
+    - name: Verify provider set correctly - 2
       tags: tests::verify
       block:
         - name: Wait for services to start


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update tests for Ansible 2.19 compatibility and address ansible-lint issues by renaming variables and clarifying task names.

Tests:
- Use "__ansible_managed" instead of "ansible_managed" in header assertion to comply with linting and Ansible 2.19 conventions
- Rename NTP provider verification task to "Verify provider set correctly - 2" to avoid duplicate task names