### PR TITLE
docs(changelog): version 1.10.2 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+[1.10.2] - 2025-07-09
+--------------------
+
+### Other Changes
+
+- ci: bump sclorg/testing-farm-as-github-action from 3 to 4 (#290)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#291)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#292)
+- ci: Add support for bootc end-to-end validation tests (#293)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#294)
+- refactor: support ansible 2.19; fix ansible-lint issues (#295)
+
 [1.10.1] - 2025-04-28
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.10.2

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation for the 1.10.2 release

Documentation:
- Add 1.10.2 section to CHANGELOG.md detailing CI action bumps, Fedora 42 and Python 3.13 support, Ansible 2.19 validation and lint fixes
- Update README.html to reflect the new version