### PR TITLE
docs(changelog): version 1.11.1 [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+[1.11.1] - 2025-11-17
+--------------------
+
+### Bug Fixes
+
+- fix: cannot use community-general version 12 - no py27 and py36 support (#312)
+
+### Other Changes
+
+- ci: bump actions/upload-artifact from 4 to 5 (#308)
+- ci: use versioned upload-artifact instead of master; bump codeql-action to v4; bump upload-artifact to v5 (#309)
+- ci: bump tox-lsr to 3.13.0 (#310)
+- ci: bump tox-lsr to 3.14.0 - this moves standard-inventory-qcow2 to tox-lsr (#311)
+
 [1.11.0] - 2025-10-21
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.11.1

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update documentation to release version 1.11.1, including changelog entries for bug fixes and CI enhancements and README HTML update

Documentation:
- Add 1.11.1 section to CHANGELOG.md documenting a bug fix and CI tool version bumps
- Update README.html for version 1.11.1