### PR TITLE
refactor: handle INJECT_FACTS_AS_VARS=false by using ansible_facts instead

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,7 +138,7 @@
     manager: auto
 
 - name: Run phc_ctl on PTP interface
-  command: phc_ctl -q {{ timesync_ptp_domains[0].interfaces[0] }}
+  command: phc_ctl -q {{ timesync_ptp_domains[0].interfaces[0] | quote }}
   register: timesync_phc_ctl_output
   changed_when: false
   check_mode: false

--- a/templates/ntpd.sysconfig.j2
+++ b/templates/ntpd.sysconfig.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 {{ "system_role:timesync" | comment(prefix="", postfix="") }}
 
-OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_distribution in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_distribution_major_version | int < 7 else '' }}{{
+OPTIONS="-g{{ ' -u ntp:ntp -p /var/run/ntpd.pid' if ansible_facts['distribution'] in ['OracleLinux', 'RedHat', 'CentOS'] and ansible_facts['distribution_major_version'] | int < 7 else '' }}{{
     ' -4' if timesync_ntp_ip_family == 'IPv4'
     else ' -6' if timesync_ntp_ip_family == 'IPv6'
     else '' }}"

--- a/tests/tests_ntp_provider6.yml
+++ b/tests/tests_ntp_provider6.yml
@@ -5,8 +5,8 @@
   hosts: all
   gather_facts: true
   vars:
-    is_ntp_default: "{{ ansible_distribution in ['RedHat', 'CentOS']
-      and ansible_distribution_version is version('7.0', '<') }}"
+    is_ntp_default: "{{ ansible_facts['distribution'] in ['RedHat', 'CentOS']
+      and ansible_facts['distribution_version'] is version('7.0', '<') }}"
     both_avail: true
 
   tasks:

--- a/tests/tests_ntp_ptp.yml
+++ b/tests/tests_ntp_ptp.yml
@@ -12,10 +12,10 @@
         maxpoll: 2
     timesync_ptp_domains:
       - number: 0
-        interfaces: "{{ [ ansible_default_ipv4['interface'] ] }}"
+        interfaces: "{{ [ ansible_facts['default_ipv4']['interface'] ] }}"
         delay: 0.0001
       - number: 1
-        interfaces: "{{ [ ansible_default_ipv4['interface'] ] }}"
+        interfaces: "{{ [ ansible_facts['default_ipv4']['interface'] ] }}"
         delay: 0.0001
     timesync_step_threshold: 0.001
     timesync_dhcp_ntp_servers: false
@@ -44,7 +44,7 @@
                      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
         - name: Check if SW/HW timestamping is supported
-          command: ethtool -T "{{ ansible_default_ipv4['interface'] }}"
+          command: ethtool -T {{ ansible_facts['default_ipv4']['interface'] | quote }}
           register: ethtool
           ignore_errors: true  # noqa ignore-errors
           changed_when: false

--- a/tests/tests_ptp_multi.yml
+++ b/tests/tests_ptp_multi.yml
@@ -5,10 +5,10 @@
   vars:
     timesync_ptp_domains:
       - number: 0
-        interfaces: "{{ [ ansible_default_ipv4['interface'] ] }}"
+        interfaces: "{{ [ ansible_facts['default_ipv4']['interface'] ] }}"
         transport: L2
       - number: 1
-        interfaces: "{{ [ ansible_default_ipv4['interface'] ] }}"
+        interfaces: "{{ [ ansible_facts['default_ipv4']['interface'] ] }}"
         delay: 0.001
         transport: UDPv4
         hybrid_e2e: true
@@ -37,7 +37,7 @@
                      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
         - name: Check if SW/HW timestamping is supported
-          command: ethtool -T "{{ ansible_default_ipv4['interface'] }}"
+          command: ethtool -T {{ ansible_facts['default_ipv4']['interface'] | quote }}
           register: ethtool
           ignore_errors: true  # noqa ignore-errors
           changed_when: false
@@ -82,8 +82,8 @@
                 that:
                   - pmc.stdout is search("portState\s+LISTENING")
               when:
-                - ansible_distribution not in ['RedHat', 'CentOS'] or
-                  ansible_distribution_version is not version('8.3', '<')
+                - ansible_facts['distribution'] not in ['RedHat', 'CentOS'] or
+                  ansible_facts['distribution_version'] is not version('8.3', '<')
 
             - name: Run pmc
               vars:
@@ -105,5 +105,5 @@
                 that:
                   - pmc.stdout is search("portState\s+LISTENING")
               when:
-                - ansible_distribution not in ['RedHat', 'CentOS'] or
-                  ansible_distribution_version is not version('8.3', '<')
+                - ansible_facts['distribution'] not in ['RedHat', 'CentOS'] or
+                  ansible_facts['distribution_version'] is not version('8.3', '<')

--- a/tests/tests_ptp_single.yml
+++ b/tests/tests_ptp_single.yml
@@ -5,7 +5,7 @@
   vars:
     timesync_ptp_domains:
       - number: 3
-        interfaces: "{{ [ ansible_default_ipv4['interface'] ] }}"
+        interfaces: "{{ [ ansible_facts['default_ipv4']['interface'] ] }}"
   roles:
     - linux-system-roles.timesync
 
@@ -28,7 +28,7 @@
                      ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
         - name: Check if SW/HW timestamping is supported
-          command: ethtool -T "{{ ansible_default_ipv4['interface'] }}"
+          command: ethtool -T {{ ansible_facts['default_ipv4']['interface'] | quote }}
           register: ethtool
           ignore_errors: true  # noqa ignore-errors
           changed_when: false
@@ -57,5 +57,5 @@
                 that:
                   - pmc.stdout is search("portState\s+LISTENING")
               when:
-                - ansible_distribution not in ['RedHat', 'CentOS'] or
-                  ansible_distribution_version is not version('8.3', '<')
+                - ansible_facts['distribution'] not in ['RedHat', 'CentOS'] or
+                  ansible_facts['distribution_version'] is not version('8.3', '<')

--- a/tests/vars/rh_distros_vars.yml
+++ b/tests/vars/rh_distros_vars.yml
@@ -14,7 +14,7 @@ __timesync_rh_distros:
 __timesync_rh_distros_fedora: "{{ __timesync_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__timesync_is_rh_distro: "{{ ansible_distribution in __timesync_rh_distros }}"
+__timesync_is_rh_distro: "{{ ansible_facts['distribution'] in __timesync_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__timesync_is_rh_distro_fedora: "{{ ansible_distribution in __timesync_rh_distros_fedora }}"
+__timesync_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __timesync_rh_distros_fedora }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -31,8 +31,8 @@ __timesync_rh_distros:
 __timesync_rh_distros_fedora: "{{ __timesync_rh_distros + ['Fedora'] }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone
-__timesync_is_rh_distro: "{{ ansible_distribution in __timesync_rh_distros }}"
+__timesync_is_rh_distro: "{{ ansible_facts['distribution'] in __timesync_rh_distros }}"
 
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
-__timesync_is_rh_distro_fedora: "{{ ansible_distribution in __timesync_rh_distros_fedora }}"
+__timesync_is_rh_distro_fedora: "{{ ansible_facts['distribution'] in __timesync_rh_distros_fedora }}"
 # END - DO NOT EDIT THIS BLOCK - rh distros variables


### PR DESCRIPTION
Ansible 2.20 has deprecated the use of Ansible facts as variables.  For
example, `ansible_distribution` is now deprecated in favor of
`ansible_facts["distribution"]`.  This is due to making the default
setting `INJECT_FACTS_AS_VARS=false`.  For now, this will create WARNING
messages, but in Ansible 2.24 it will be an error.

See https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.20.html#inject-facts-as-vars

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update Ansible role and tests to use ansible_facts-based lookups instead of legacy fact variables to comply with INJECT_FACTS_AS_VARS=false and upcoming Ansible deprecations.

Enhancements:
- Replace direct use of injected Ansible fact variables (e.g. ansible_distribution, ansible_default_ipv4) with ansible_facts lookups across role vars, templates, and test playbooks.
- Quote network interface values in shell/command invocations to ensure safe handling of fact-derived interface names.