### PR TITLE
ci: debugging for container tests

### DIFF
--- a/tests/tests_chrony.yml
+++ b/tests/tests_chrony.yml
@@ -21,9 +21,6 @@
     timesync_min_sources: 2
 
   tasks:
-    - name: Fail
-      fail:
-
     - name: Run the role
       include_role:
         name: linux-system-roles.timesync


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update CI integration test workflow to focus on container bootc scenarios and enable debugging for container tests via a custom tox-lsr fork.

CI:
- Restrict QEMU/KVM integration test matrix to container bootc scenarios only.
- Switch tox-lsr installation in the CI workflow to a debug-focused fork for container tests.
- Remove container profile/pretty environment overrides in the container test step to use default behavior.