### PR TITLE
test: support ansible-test milestone version 2.22 [citest_skip]

### DIFF
--- a/.sanity-ansible-ignore-2.22.txt
+++ b/.sanity-ansible-ignore-2.22.txt
@@ -1,0 +1,4 @@
+plugins/modules/timesync_provider.sh shebang
+plugins/modules/timesync_provider.yml validate-modules:missing-gplv3-license
+plugins/modules/timesync_provider.sh validate-modules:invalid-extension
+plugins/modules/timesync_provider.sh validate-modules:missing-gplv3-license


### PR DESCRIPTION
The ansible milestone branch is now version 2.22

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Add configuration support for ansible-test milestone version 2.22.

Tests:
- Introduce a new ansible sanity ignore configuration file for milestone version 2.22.

Chores:
- Add version-specific ignore file for ansible-test 2.22 to align with the new milestone branch.