### PR TITLE
fix: add verbosity-based no_log to facts modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 
 - name: Populate service facts
   service_facts:
+  no_log: "{{ ansible_verbosity < 2 }}"
   when: __timesync_is_booted | d(false)
 
 - name: Set variable `timesync_services` with filtered uniq service names
@@ -137,6 +138,7 @@
 - name: Gather package facts
   package_facts:
     manager: auto
+  no_log: "{{ ansible_verbosity < 2 }}"
 
 - name: Run phc_ctl on PTP interface
   command: phc_ctl -q {{ timesync_ptp_domains[0].interfaces[0] | quote }}


### PR DESCRIPTION
Feature: Add verbosity-based no_log to facts modules.

Reason: Facts modules like package_facts and service_facts produce verbose output that clutters logs during normal operation, making it difficult to review playbook execution.

Result:
  - package_facts and service_facts now use no_log: "{{ ansible_verbosity < 2 }}", hiding verbose output unless -vv or higher verbosity is specified
  - Users can still see full facts output when debugging by running with increased verbosity
  - No impact on normal operation, just cleaner logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Control verbosity of facts gathering tasks to reduce log noise in normal runs while preserving debug visibility.

New Features:
- Add verbosity-based no_log control to service_facts to hide output below -vv verbosity.
- Add verbosity-based no_log control to package_facts to hide output below -vv verbosity.