### PR TITLE
test: ensure fingerprint test works in check mode

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -17,25 +17,10 @@
       vars:
         __timesync_write_log_file: true
 
-    - name: Get fingerprint entries from journal
-      ansible.builtin.shell:
-        executable: /bin/bash
-        cmd: >-
-          set -eo pipefail;
-          journalctl --since "{{ __journal_start_time }}" --no-pager |
-          grep -v " Invoked with" |
-          grep "sr_fingerprint.*role_name=timesync"
-      register: __register_journal_fingerprints
-      changed_when: false
-      when: __register_dev_log.stat.exists
-
-    - name: Check that the log file was written
-      ansible.builtin.slurp:
-        path: /var/log/sysroles.jsonl
-      register: __register_log_file
-
     - name: Verify log file and journal fingerprints
-      when: __register_dev_log.stat.exists
+      when:
+        - not ansible_check_mode
+        - __register_dev_log.stat.exists
       vars:
         __journal_lines: "{{ __register_journal_fingerprints.stdout_lines }}"
         __journal_begin: "{{ __journal_lines | select('search', 'status=begin') | list }}"
@@ -44,6 +29,23 @@
         __success_date: "{{ (__journal_success[0] | regex_search('date=([^ ]+)', '\\1'))[0] }}"
         __file_content: "{{ __register_log_file.content | b64decode }}"
       block:
+        - name: Get fingerprint entries from journal
+          ansible.builtin.shell:
+            executable: /bin/bash
+            cmd: >-
+              set -eo pipefail;
+              journalctl --since "{{ __journal_start_time }}" --no-pager |
+              grep -v " Invoked with" |
+              grep "sr_fingerprint.*role_name=timesync"
+          register: __register_journal_fingerprints
+          changed_when: false
+          when: __register_dev_log.stat.exists
+
+        - name: Check that the log file was written
+          ansible.builtin.slurp:
+            path: /var/log/sysroles.jsonl
+          register: __register_log_file
+
         - name: Print contents of logs
           debug:
             var: item

--- a/tests/tests_default_wrapper.yml
+++ b/tests/tests_default_wrapper.yml
@@ -41,8 +41,16 @@
         --check tests_default.yml
       changed_when: false
       delegate_to: localhost
+      register: __check_mode_result
+      failed_when: __check_mode_result is failed
+        or __check_mode_result.stdout_lines | select('search', _begin_pattern) | list | length == 0
+        or __check_mode_result.stdout_lines | select('search', _success_pattern) | list | length == 0
       vars:
         __ap_cmd: "{{ ansible_playbook_filepath | d('ansible-playbook') }}"
+        _begin_pattern: >-
+          Check mode: message not logged - .* role_name=timesync .* status=begin .* ansible_check_mode=[Tt]rue
+        _success_pattern: >-
+          Check mode: message not logged - .* role_name=timesync .* status=success .* ansible_check_mode=[Tt]rue
 
     - name: Remove the temporary file
       file:


### PR DESCRIPTION
The fingerprint journal messages and the fingerprint log file
are not written in check mode.  Ensure that the correct messages
are written in check mode.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification and log collection now run only when applicable, preventing failures in check mode or when `/dev/log` is unavailable.
  * Improved check-mode validation to confirm expected time synchronization messages and check-mode status.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->